### PR TITLE
Feature/pge 28 Dashboard: Weitere aggregierte Werte

### DIFF
--- a/apps/web/src/app/(app)/(site)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/(site)/dashboard/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import AbsolutEnergyConsumptionCard from "@/components/dashboard/absolut-energy-consumption-card";
 import EnergyConsumptionCard from "@/components/dashboard/energy-consumption-card";
 import EnergyCostCard from "@/components/dashboard/energy-cost-card";
+import EnergyStatisticsCard from "@/components/dashboard/energy-consumption-statistics"
 
 import { Skeleton } from "@energyleaf/ui";
 
@@ -21,6 +22,9 @@ export default function DashboardPage({
             <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                 <Suspense fallback={<Skeleton className="h-72 w-full" />}>
                     <AbsolutEnergyConsumptionCard endDate={endDate} startDate={startDate} />
+                </Suspense>
+                <Suspense fallback={<Skeleton className="h-72 w-full" />}>
+                    <EnergyStatisticsCard endDate={endDate} startDate={startDate} />
                 </Suspense>
                 <Suspense fallback={<Skeleton className="h-72 w-full" />}>
                     <EnergyCostCard endDate={endDate} startDate={startDate} />

--- a/apps/web/src/components/dashboard/energy-consumption-statistics.tsx
+++ b/apps/web/src/components/dashboard/energy-consumption-statistics.tsx
@@ -63,7 +63,7 @@ export default async function EnergyConsumptionStatisticCard({ startDate, endDat
                                 {format(new Date(maxConsumptionDate), "dd.MM.yyyy HH:mm")} Uhr
                             </p>
                         )}
-                        <p className="text-center">{maxConsumption} kWh</p>
+                        <p className="text-center">{maxConsumption ?? 0} kWh</p>
                     </div>
                     <div>
                         <h2 className="text-center text-xl font-semibold text-primary">⌀</h2>
@@ -71,7 +71,7 @@ export default async function EnergyConsumptionStatisticCard({ startDate, endDat
                     </div>
                     <div>
                         <h2 className="text-center text-xl font-semibold text-primary">Letzter</h2>
-                        <p className="text-center">{lastValue} kWh</p>
+                        <p className="text-center">{lastValue ?? 0} kWh</p>
                     </div>
                 </div>
             </CardContent>

--- a/apps/web/src/components/dashboard/energy-consumption-statistics.tsx
+++ b/apps/web/src/components/dashboard/energy-consumption-statistics.tsx
@@ -1,0 +1,80 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/auth";
+import { getEnergyDataForUser } from "@/query/energy";
+import { format } from "date-fns";
+import de from "date-fns/locale/de";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@energyleaf/ui";
+
+interface Props {
+    startDate: Date;
+    endDate: Date;
+}
+
+export default async function EnergyConsumptionStatisticCard({ startDate, endDate }: Props) {
+    const session = await getSession();
+
+    if (!session) {
+        redirect("/");
+    }
+
+    const energyData = await getEnergyDataForUser(startDate, endDate, session.user.id);
+    const energyValues = energyData.map(entry => entry.value);
+
+    const maxConsumptionEntry = energyData.reduce((prev, current) => (prev.value > current.value ? prev : current), {});
+    const maxConsumption = maxConsumptionEntry.value;
+    const maxConsumptionDate = maxConsumptionEntry.timestamp;
+    
+    const sumConsumption = energyValues.reduce((acc, cur) => acc + cur, 0);
+    const averageConsumption = energyValues.length > 0 ? sumConsumption / energyValues.length : 0;
+
+    const lastValue = energyValues.length > 0 ? energyValues[energyValues.length - 1] : null;
+
+    return (
+        <Card className="w-full">
+            <CardHeader>
+                <CardTitle>Verbrauchsstatistiken</CardTitle>
+                <CardDescription>
+                    {startDate.toDateString() === endDate.toDateString() ? (
+                        <>
+                            {format(startDate, "PPP", {
+                                locale: de,
+                            })}
+                        </>
+                    ) : (
+                        <>
+                            {format(startDate, "PPP", {
+                                locale: de,
+                            })}{" "}
+                            -{" "}
+                            {format(endDate, "PPP", {
+                                locale: de,
+                            })}
+                        </>
+                    )}
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                <div className="grid grid-cols-3 gap-4">
+                    <div>
+                        <h2 className="text-center text-xl font-semibold text-primary">Max.</h2>
+                        {/* Das Datum wird hier im passenden Design angezeigt */}
+                        {maxConsumptionDate && (
+                            <p className="text-center text-xs text-muted-foreground">
+                                {format(new Date(maxConsumptionDate), "dd.MM.yyyy HH:mm")} Uhr
+                            </p>
+                        )}
+                        <p className="text-center">{maxConsumption} kWh</p>
+                    </div>
+                    <div>
+                        <h2 className="text-center text-xl font-semibold text-primary">⌀</h2>
+                        <p className="text-center">{averageConsumption.toFixed(2)} kWh</p>
+                    </div>
+                    <div>
+                        <h2 className="text-center text-xl font-semibold text-primary">Letzter</h2>
+                        <p className="text-center">{lastValue} kWh</p>
+                    </div>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/apps/web/src/components/dashboard/energy-consumption-statistics.tsx
+++ b/apps/web/src/components/dashboard/energy-consumption-statistics.tsx
@@ -20,14 +20,13 @@ export default async function EnergyConsumptionStatisticCard({ startDate, endDat
     const energyData = await getEnergyDataForUser(startDate, endDate, session.user.id);
     const energyValues = energyData.map(entry => entry.value);
 
-    const maxConsumptionEntry = energyData.reduce((prev, current) => (prev.value > current.value ? prev : current), {});
-    const maxConsumption = maxConsumptionEntry.value;
-    const maxConsumptionDate = maxConsumptionEntry.timestamp;
-    
+    const maxConsumptionEntry = energyData.reduce((prev, current) => (prev.value > current.value ? prev : current), {});  
+      
     const sumConsumption = energyValues.reduce((acc, cur) => acc + cur, 0);
     const averageConsumption = energyValues.length > 0 ? sumConsumption / energyValues.length : 0;
 
     const lastValue = energyValues.length > 0 ? energyValues[energyValues.length - 1] : null;
+
 
     return (
         <Card className="w-full">
@@ -57,13 +56,7 @@ export default async function EnergyConsumptionStatisticCard({ startDate, endDat
                 <div className="grid grid-cols-3 gap-4">
                     <div>
                         <h2 className="text-center text-xl font-semibold text-primary">Max.</h2>
-                        {/* Das Datum wird hier im passenden Design angezeigt */}
-                        {maxConsumptionDate && (
-                            <p className="text-center text-xs text-muted-foreground">
-                                {format(new Date(maxConsumptionDate), "dd.MM.yyyy HH:mm")} Uhr
-                            </p>
-                        )}
-                        <p className="text-center">{maxConsumption ?? 0} kWh</p>
+                        <p className="text-center">{maxConsumptionEntry.value ?? 0} kWh</p>
                     </div>
                     <div>
                         <h2 className="text-center text-xl font-semibold text-primary">⌀</h2>

--- a/apps/web/src/components/dashboard/energy-consumption-statistics.tsx
+++ b/apps/web/src/components/dashboard/energy-consumption-statistics.tsx
@@ -10,6 +10,10 @@ interface Props {
     endDate: Date;
 }
 
+interface EnergyDataItem {
+    value: number;
+  }
+
 export default async function EnergyConsumptionStatisticCard({ startDate, endDate }: Props) {
     const session = await getSession();
 
@@ -19,8 +23,12 @@ export default async function EnergyConsumptionStatisticCard({ startDate, endDat
 
     const energyData = await getEnergyDataForUser(startDate, endDate, session.user.id);
     const energyValues = energyData.map(entry => entry.value);
-
-    const maxConsumptionEntry = energyData.reduce((prev, current) => (prev.value > current.value ? prev : current), {});  
+      
+    const maxConsumptionEntry: EnergyDataItem = energyData.reduce(
+    (prev, current) => (prev.value > current.value ? prev : current),
+    { value: 0 }
+    );
+    const maxConsumption = maxConsumptionEntry.value || 0;
       
     const sumConsumption = energyValues.reduce((acc, cur) => acc + cur, 0);
     const averageConsumption = energyValues.length > 0 ? sumConsumption / energyValues.length : 0;
@@ -56,7 +64,7 @@ export default async function EnergyConsumptionStatisticCard({ startDate, endDat
                 <div className="grid grid-cols-3 gap-4">
                     <div>
                         <h2 className="text-center text-xl font-semibold text-primary">Max.</h2>
-                        <p className="text-center">{maxConsumptionEntry.value ?? 0} kWh</p>
+                        <p className="text-center">{maxConsumption} kWh</p>
                     </div>
                     <div>
                         <h2 className="text-center text-xl font-semibold text-primary">⌀</h2>


### PR DESCRIPTION
Dem Dashboard wurde eine neue EnergyStatisticsCard hinzugefügt, um mehr Verbrauchsinformationen über einen bestimmten Zeitraum zu erhalten. Über das Design lässt sich evtl. nochmal diskutieren, aber die Funktionalität sollte passen.
<img width="1274" alt="Bildschirmfoto 2023-12-17 um 14 17 34" src="https://github.com/pgenergy/energyleaf/assets/129761217/5e4f90aa-ca0c-491d-82c4-ef1baa269713">

