### PR TITLE
pge68-frontend-anpassen-von-LineCharts-und-Tooltip

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,10 +1,10 @@
 NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=<secret>
+NEXTAUTH_SECRET=123
 
-DATABASE_HOST=<host>
-DATABASE_USERNAME=<user>
-DATABASE_PASSWORD=<password>
+DATABASE_HOST=aws.connect.psdb.cloud
+DATABASE_USERNAME=jwzg2czovznt9wfc0rn0
+DATABASE_PASSWORD=pscale_pw_qes1NJsBMb964BGmMMNS4N05dLNMJYM90EdoX8S3ucl
 DATABASE_NAME=energyleaf
-DATABASE_PUSH_URL=mysql://root@127.0.0.1:3309/energyleaf
+DATABASE_PUSH_URL=mysql://jwzg2czovznt9wfc0rn0@aws.connect.psdb.cloud:3309/energyleaf
 
-SENDGRID_API_KEY=<sendgrid_key>
+SENDGRID_API_KEY=<sendgrid_key>pnp

--- a/apps/web/src/app/(site)/linechart/page.tsx
+++ b/apps/web/src/app/(site)/linechart/page.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from "react";
+import EnergyConsumptionCard from "@/components/dashboard/energy-consumption-card";
+
+import { Skeleton } from "@energyleaf/ui";
+
+export default function DashboardPage({
+                                          searchParams,
+                                      }: {
+    searchParams: { start?: string; end?: string; aggregation?: string };
+}) {
+    const startDateString = searchParams.start;
+    const endDateString = searchParams.end;
+    const aggregationType = searchParams.aggregation;
+    const startDate = startDateString ? new Date(startDateString) : new Date();
+    const endDate = endDateString ? new Date(endDateString) : new Date();
+
+    return (
+        <div className="flex flex-col gap-4">
+            <Suspense fallback={<Skeleton className="h-[57rem] w-full" />}>
+                <EnergyConsumptionCard aggregationType={aggregationType} endDate={endDate} startDate={startDate} />
+            </Suspense>
+        </div>
+    );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,24 +1,60 @@
-import { ThemeProvider } from "@/hooks/theme-provider";
-import "@energyleaf/tailwindcss/global.css";
-import { Toaster } from "@energyleaf/ui/components/utils";
+import { redirect } from "next/navigation";
+import Footer from "@/components/footer/footer";
+import NavbarAvatar from "@/components/nav/navbar-avatar";
+import ThemeSwitcher from "@/components/nav/theme-switcher";
+import { getSession } from "@/lib/auth/auth";
+import {HomeIcon, LightbulbIcon, LineChartIcon, MicrowaveIcon} from "lucide-react";
 
-import type { Metadata } from "next";
+import { Navbar, Sidebar } from "@energyleaf/ui/components/nav";
 
-export const metadata: Metadata = {
-    title: "Energyleaf",
-};
-export const revalidate = 0;
+const navLinks = [
+    {
+        slug: "dashboard",
+        title: "Übersicht",
+        path: "/dashboard",
+        icon: <HomeIcon className="mr-2 h-4 w-4" />,
+    },
+    {
+        slug: "recommendations",
+        title: "Empfehlungen",
+        path: "/recommendations",
+        icon: <LightbulbIcon className="mr-2 h-4 w-4" />,
+    },
+    {
+        slug: "devices",
+        title: "Geräte",
+        path: "/devices",
+        icon: <MicrowaveIcon className="mr-2 h-4 w-4" />,
+    },
+    {
+        slug: "linechart",
+        title: "Verbrauch",
+        path: "/linechart",
+        icon: <LineChartIcon className="mr-2 h-4 w-4" />,
+    },
+];
 
-export default function RootLayout({ children }: { children: React.ReactNode }): JSX.Element {
+export default async function SiteLayout({ children }: { children: React.ReactNode }) {
+    const session = await getSession();
+
+    if (!session) {
+        redirect("/");
+    }
     return (
-        <html lang="de">
-            <head />
-            <body>
-                <ThemeProvider attribute="class" defaultTheme="system" disableTransitionOnChange enableSystem>
-                    {children}
-                    <Toaster richColors />
-                </ThemeProvider>
-            </body>
-        </html>
+        <>
+            <Navbar
+                actions={
+                    <>
+                        <ThemeSwitcher />
+                        <NavbarAvatar user={session.user} />
+                    </>
+                }
+                title="Energyleaf"
+                titleLink="/dashboard"
+            />
+            <Sidebar links={navLinks} />
+            <main className="ml-[13%] mt-14 px-8 py-8">{children}</main>
+            <Footer />
+        </>
     );
 }

--- a/apps/web/src/components/dashboard/energy-aggregation-option.tsx
+++ b/apps/web/src/components/dashboard/energy-aggregation-option.tsx
@@ -2,14 +2,8 @@
 
 import React from "react";
 import { usePathname, useRouter } from "next/navigation";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@energyleaf/ui";
-import { AggregationType } from "@/types/aggregation/aggregation-type";
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@energyleaf/ui";
 
 interface Props {
     startDate: Date;
@@ -36,11 +30,10 @@ export default function EnergyAggreation({ startDate, endDate }: Props) {
                     <SelectValue placeholder="Granularität" />
                 </SelectTrigger>
                 <SelectContent>
-                    <SelectItem value={AggregationType.RAW}>Nicht aggregiert</SelectItem>
-                    <SelectItem value={AggregationType.HOUR}>Stunde</SelectItem>
-                    <SelectItem value={AggregationType.DAY}>Tag</SelectItem>
-                    <SelectItem value={AggregationType.MONTH}>Monat</SelectItem>
-                    <SelectItem value={AggregationType.YEAR}>Jahr</SelectItem>
+                    <SelectItem value="hour">Verbrauch / Stunde</SelectItem>
+                    <SelectItem value="day">Verbrauch / Tag</SelectItem>
+                    <SelectItem value="month">Verbrauch / Monat</SelectItem>
+                    <SelectItem value="year">Verbrauch / Jahr</SelectItem>
                 </SelectContent>
             </Select>
         </div>

--- a/apps/web/src/components/dashboard/energy-consumption-card-chart.tsx
+++ b/apps/web/src/components/dashboard/energy-consumption-card-chart.tsx
@@ -1,32 +1,55 @@
 "use client";
 
-import { LineChart } from "@energyleaf/ui/components/charts";
+import { useState } from "react";
+
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, TextArea } from "@energyleaf/ui";
+import { LineChart } from "@energyleaf/ui/components";
 
 import EnergyConsumptionTooltip from "./energy-consumption-tooltip";
 
-type AxesValue = string | number | undefined;
-
 interface Props {
-    data: Record<string, AxesValue>[];
-    referencePoints?: {
-        data: Record<string, AxesValue>[];
-        xKeyName: string;
-        yKeyName: string;
-        callback?: (value: Record<string, AxesValue>) => void;
-    };
+    data: Record<string, string | number | undefined>[];
+    peaks: Record<string, string | number | undefined>[];
 }
 
-export default function EnergyConsumptionCardChart({ data, referencePoints }: Props) {
+export default function EnergyConsumptionCardChart({ data, peaks }: Props) {
+    const [open, setOpen] = useState(false);
+    const [value, setValue] = useState<Record<string, string | number | undefined>>({});
+
     return (
-        <LineChart
-            data={data}
-            keyName="energy"
-            referencePoints={referencePoints}
-            tooltip={{
-                content: EnergyConsumptionTooltip,
-            }}
-            xAxes={{ dataKey: "timestamp" }}
-            yAxes={{ dataKey: "energy", name: "Energieverbauch in Wh" }}
-        />
+        <>
+            <Dialog onOpenChange={setOpen} open={open}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Geräteauswahl</DialogTitle>
+                        <DialogDescription>Wähle ein Gerät aus, was diesen Verbrauch verursacht hat.</DialogDescription>
+                    </DialogHeader>
+                    <h1 className="p-8 text-center">TODO</h1>
+                    <p>Verbrauch: {value.energy}</p>
+                </DialogContent>
+            </Dialog>
+            <LineChart
+                data={data}
+                keyName="energy"
+                referencePoints={{
+                    data: peaks,
+                    xKeyName: "timestamp",
+                    yKeyName: "energy",
+                    callback: (callbackData) => {
+                        setValue(callbackData);
+                        setOpen(true);
+                    },
+                }}
+                tooltip={{
+                    content: EnergyConsumptionTooltip,
+                }}
+                xAxes={{
+                    dataKey: "timestamp", name: new URLSearchParams(window.location.search).get('aggregation') == "hour" ? "Vergangene Zeit in Stunde" :
+                        new URLSearchParams(window.location.search).get('aggregation') == "day" ? "Vergangene Zeit in Tage" :
+                            new URLSearchParams(window.location.search).get('aggregation') == "month" ? "Vergangene Zeit in Monate" : "Vergangene Zeit in Jahre"
+                }}
+                yAxes={{ dataKey: "energy", name: "Energieverbauch in Wh" }}
+            />
+        </>
     );
 }

--- a/apps/web/src/components/dashboard/energy-consumption-card.tsx
+++ b/apps/web/src/components/dashboard/energy-consumption-card.tsx
@@ -35,7 +35,7 @@ export default async function EnergyConsumptionCard({ startDate, endDate, aggreg
         energy: entry.value,
         timestamp: entry.timestamp.toString(),
     }));
-    
+
     const realAggregationType = aggregationType || AggregationType.RAW;
     const aggregatedDataInput = getAggregatedEnergy(data, realAggregationType);
     const aggregatedData = aggregatedDataInput.map((entry) => ({
@@ -47,7 +47,7 @@ export default async function EnergyConsumptionCard({ startDate, endDate, aggreg
 
     let peakAssignments: PeakAssignment[] = [];
     const devices = noAggregation ? await getDevicesByUser(userId) : [];
-    
+
     if (noAggregation) {
         const mean = data.reduce((acc, cur) => acc + cur.energy, 0) / data.length;
         const std = Math.sqrt(
@@ -78,8 +78,8 @@ export default async function EnergyConsumptionCard({ startDate, endDate, aggreg
     function Chart() {
         return (
             noAggregation ?
-            <RawEnergyConsumptionCardChart data={data} devices={devices} peaks={peakAssignments}  /> :
-            <EnergyConsumptionCardChart data={aggregatedData} />
+                <RawEnergyConsumptionCardChart data={data} devices={devices} peaks={peakAssignments}  /> :
+                <EnergyConsumptionCardChart data={aggregatedData} />
         )
     }
 
@@ -88,7 +88,7 @@ export default async function EnergyConsumptionCard({ startDate, endDate, aggreg
             <CardHeader className="flex flex-row justify-between">
                 <div className="flex flex-col gap-2">
                     <CardTitle>Verbrauch</CardTitle>
-                    <CardDescription>Übersicht deines Verbrauchs im Zeitraum</CardDescription>
+                    <CardDescription>Übersicht deines Verbrauchs im Zeitraum, für eine detaillierte Darstellung Granularität wählen</CardDescription>
                 </div>
                 <div className="flex flex-row gap-4">
                     <DashboardDateRange endDate={endDate} startDate={startDate} />

--- a/apps/web/src/components/dashboard/energy-consumption-tooltip.tsx
+++ b/apps/web/src/components/dashboard/energy-consumption-tooltip.tsx
@@ -9,9 +9,9 @@ import { Card, CardContent, CardDescription, CardHeader } from "@energyleaf/ui";
 export default function EnergyConsumptionTooltip({ payload }: TooltipProps<ValueType, NameType>) {
     const data = payload?.[0]?.payload as
         | {
-              energy: number;
-              timestamp: string;
-          }
+        energy: number;
+        timestamp: string;
+    }
         | undefined;
     const energy = data?.energy;
     const timestamp = data?.timestamp;
@@ -20,6 +20,9 @@ export default function EnergyConsumptionTooltip({ payload }: TooltipProps<Value
         return null;
     }
 
+    const searchParams = new URLSearchParams(window.location.search);
+    const aggregationType = searchParams.get('aggregation');
+
     return (
         <Card className="z-10">
             <CardHeader>
@@ -27,7 +30,11 @@ export default function EnergyConsumptionTooltip({ payload }: TooltipProps<Value
             </CardHeader>
             <CardContent className="flex flex-col gap-2">
                 <p className="text-sm">
-                    <span className="font-bold">Verbrauch:</span> {energy} Wh
+                    <span className="font-bold">Verbrauch:</span> {energy} Wh / {(
+                    aggregationType == "hour" ? "Stunde" :
+                        aggregationType == "day" ? "Tag" :
+                            aggregationType == "month" ? "Monat" : "Jahr"
+                )}
                 </p>
             </CardContent>
         </Card>


### PR DESCRIPTION
Anpassungen:
1. Menüpunkt "Verbrauch" hinzugefügt zu layout.tsx.
2. Neue Seite "linechart" unter app/(app)/(site) für das Routing hinzugefügt 2.1. Duplizieren der Seite /dashboard und entfernen der anderen Modulen

Anpassungen:
1. Werte der Granularitäten angepasst
2. xAchsenbeschreibung in Abhängigkeit der Granularität gesetzt. 3.Das Liniendiagramm wird erst nach erneutem Laden der Seite geladen und die xAchsenbeschriftung wird korrekt angezeigt
3. Die Granularität wird im Tooltip anhand der URL ausgelesen