### PR TITLE
Add .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# idea
+.idea


### PR DESCRIPTION
e. g. for Webstorm support

Ich benutze seit kurzem Webstorm und habe keine Lust, das auf jedem Branch neu anzupassen, bis das irgendwann gemergt ist.