### PR TITLE
Feature/pge 136 dashboard start datum kann bei zeitraumauswahl nicht

### DIFF
--- a/apps/web/src/app/(site)/dashboard/page.tsx
+++ b/apps/web/src/app/(site)/dashboard/page.tsx
@@ -23,11 +23,11 @@ export default function DashboardPage({
     const endDate = endDateString ? new Date(endDateString) : new Date();
 
     if (!startDateString) {
-        startDate.setUTCHours(0, 0, 0, 0);
+        startDate.setHours(0, 0, 0, 0);
     }
 
     if (!endDateString) {
-        endDate.setUTCHours(23, 59, 59, 999);
+        endDate.setHours(23, 59, 59, 999);
     }
 
     return (

--- a/apps/web/src/components/dashboard/date-range.tsx
+++ b/apps/web/src/components/dashboard/date-range.tsx
@@ -28,6 +28,10 @@ export default function DashboardDateRange({ startDate: initStartDate, endDate: 
     }, [initStartDate, initEndDate]);
     const [range, setRange] = useState<DateRange | undefined>(initRange);
 
+    const calFooter = useMemo(() => {
+       return range?.from && range?.to ? null : <p>Bitte geben Sie einen Zeitraum an.</p>;
+    }, [range]);
+
     const dateString = () => {
         if (initStartDate.toDateString() === initEndDate.toDateString()) {
             return format(initStartDate, "PPP", {
@@ -121,6 +125,7 @@ export default function DashboardDateRange({ startDate: initStartDate, endDate: 
                         mode="range"
                         onSelect={onChange}
                         selected={range}
+                        footer={calFooter}
                     />
                 </PopoverContent>
             </Popover>

--- a/apps/web/src/components/dashboard/date-range.tsx
+++ b/apps/web/src/components/dashboard/date-range.tsx
@@ -29,7 +29,7 @@ export default function DashboardDateRange({ startDate: initStartDate, endDate: 
     const [range, setRange] = useState<DateRange | undefined>(initRange);
 
     const calFooter = useMemo(() => {
-       return range?.from && range?.to ? null : <p>Bitte geben Sie einen Zeitraum an.</p>;
+       return range?.from && range.to ? null : <p>Bitte geben Sie einen Zeitraum an.</p>;
     }, [range]);
 
     const dateString = () => {


### PR DESCRIPTION
In der Zeitraumauswahl-Komponente gibt es jetzt einen expliziten State für die DateRange. Auf diese Weise kann man die Funktionalität von der DayPicker-Komonente verwenden, um die Auswahl zurückzusetzen. So kann man dann ein neuen Start-Datum setzen.

[Bildschirmaufzeichnung vom 12.03.2024, 11:41:58.webm](https://github.com/pgenergy/energyleaf/assets/58442405/07e6a258-0c89-4812-ae91-407fb670e50b)
