### PR TITLE
Ignore initial meter reading of sensor when calculating user goals

### DIFF
--- a/packages/db/src/query/sensor.ts
+++ b/packages/db/src/query/sensor.ts
@@ -134,7 +134,7 @@ export async function getEnergySumForSensorInRange(start: Date, end: Date, senso
             .orderBy(desc(sensorData.timestamp))
             .limit(1);
 
-        let valueBeforeStart;
+        let valueBeforeStart: number;
         if (latestEntryBeforeStart.length > 0) {
             valueBeforeStart = latestEntryBeforeStart[0].value;
         } else {

--- a/packages/db/src/query/sensor.ts
+++ b/packages/db/src/query/sensor.ts
@@ -1,6 +1,6 @@
 import { AggregationType } from "@energyleaf/lib";
 import { SensorAlreadyExistsError } from "@energyleaf/lib/errors/sensor";
-import { and, between, desc, eq, lt, lte, or, sql } from "drizzle-orm";
+import { and, between, desc, eq, gte, lt, lte, or, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import db from "../";
 import { device, peaks, sensor, sensorData, sensorHistory, sensorToken, user, userData } from "../schema";
@@ -133,7 +133,19 @@ export async function getEnergySumForSensorInRange(start: Date, end: Date, senso
             .where(and(eq(sensorData.sensorId, sensorId), lt(sensorData.timestamp, start)))
             .orderBy(desc(sensorData.timestamp))
             .limit(1);
-        const valueBeforeStart = latestEntryBeforeStart.length > 0 ? latestEntryBeforeStart[0].value : 0;
+
+        let valueBeforeStart;
+        if (latestEntryBeforeStart.length > 0) {
+            valueBeforeStart = latestEntryBeforeStart[0].value;
+        } else {
+            const firstSensorEntry = await trx
+                .select({ value: sensorData.value })
+                .from(sensorData)
+                .where(and(eq(sensorData.sensorId, sensorId), gte(sensorData.timestamp, start)))
+                .orderBy(sensorData.timestamp)
+                .limit(1);
+            valueBeforeStart = firstSensorEntry.length > 0 ? firstSensorEntry[0].value : 0;
+        }
 
         const latestEntryBeforeEnd = await trx
             .select({ value: sensorData.value })


### PR DESCRIPTION
Bei der Differenz muss man gucken, ob es vor dem Betrachtungszeitraum keine Daten gibt. Falls ja, dann muss der letzte Eintrag vom ersten Eintrag innerhalb des Betrachtungszeitraums (der initiale Zählerstand) abgezogen werden.