### PR TITLE
PGE-167: Use correct db type

### DIFF
--- a/packages/db/src/schema/sensor.ts
+++ b/packages/db/src/schema/sensor.ts
@@ -1,7 +1,6 @@
 import { sql } from "drizzle-orm";
 import {
     boolean,
-    decimal,
     int,
     mysqlEnum,
     mysqlTable,
@@ -13,6 +12,7 @@ import {
 } from "drizzle-orm/mysql-core";
 import { nanoid } from "nanoid";
 import { SensorType } from "../types/types";
+import { decimalType } from "../types/dbTypes";
 
 const sensorTypes = [SensorType.Electricity, SensorType.Gas] as const;
 
@@ -58,7 +58,7 @@ export const sensorData = mysqlTable(
             .notNull()
             .$defaultFn(() => nanoid(35)),
         sensorId: varchar("sensor_id", { length: 30 }).notNull(),
-        value: decimal("value", { precision: 12, scale: 4 }).$type<number>().notNull(),
+        value: decimalType("value").notNull(),
         timestamp: timestamp("timestamp").notNull().default(sql`CURRENT_TIMESTAMP`),
     },
     (table) => {

--- a/packages/db/src/types/dbTypes.ts
+++ b/packages/db/src/types/dbTypes.ts
@@ -1,0 +1,16 @@
+import { customType } from "drizzle-orm/mysql-core";
+
+/**
+ * This type is needed because drizzle defaults to return decimal types as string
+ * this is due to the fact that the mysql decimal type can be way bigger then the js number type
+ * we only have a scale of 4, 4 digets after the point.
+ * so we can savely convert them to a number
+ */
+export const decimalType = customType<{ data: number, driverData: string }>({
+    dataType() {
+        return "decimal(12, 4)"
+    },
+    fromDriver(data: string): number {
+        return Number(data)
+    },
+});


### PR DESCRIPTION
Um am ende keine Rundungsfehler zu haben sollten wir den [decimal](https://dev.mysql.com/doc/refman/8.0/en/fixed-point-types.html) Type in MySQL verwenden.

Drizzle stellt diesen Type leider im default als string dar.
Das hängt damit zusammen, dass der decimal Type zahlen darstellen kann die in JS/TS nicht abgebildet werden können. Wir haben hier eine feste größe mit 4 Nachkommastellen und können deswegen ziemlich sicher zu einer Zahl casten.

Dafür nutzen wir einen CustomType in Drizzle, der es uns erlaubt den cast direkt durchzuführen.