### PR TITLE
Set content varchar length to 16k

### DIFF
--- a/packages/db/src/schema/logs.ts
+++ b/packages/db/src/schema/logs.ts
@@ -5,5 +5,5 @@ export const logs = mysqlTable("logs", {
     id: int("id").autoincrement().primaryKey().notNull(),
     logType: mysqlEnum("log_type", ["web", "admin", "undefined"]).default("undefined"),
     created: timestamp("created").default(sql`CURRENT_TIMESTAMP`),
-    content: varchar("content", {length: 50000}).notNull(),
+    content: varchar("content", {length: 16000}).notNull(),
 });


### PR DESCRIPTION
Man konnte auf dem aktuellen development Branch keine DB pushes mehr durchführen, weil immer folgender Fehler kam:
![grafik](https://github.com/pgenergy/energyleaf/assets/58442405/0eea7380-cc0a-4c21-bfb8-f9203942ea18)

Habe die Zeichenlänge der Logs jetzt auf 16k beschränkt, das sollte noch groß genug sein

https://app.planetscale.com/energyleaf/energyleaf/deploy-requests/39