### PR TITLE
bugfix predicted monthly costs

### DIFF
--- a/apps/web/src/components/dashboard/energy-cost.tsx
+++ b/apps/web/src/components/dashboard/energy-cost.tsx
@@ -106,7 +106,8 @@ export function getPredictedCost(userData: UserDataSelectType[], energyData: Sen
         return 0;
     }
 
-    const price = getLatestUserData(userData).basePrice ?? 0;
+    const workingPrice = getLatestUserData(userData).workingPrice ?? 0;
+    const basePrice = getLatestUserData(userData).basePrice ?? 0;
 
     const today: Date = new Date();
     const firstDayOfMonth: Date = new Date(today.getFullYear(), today.getMonth(), 1);
@@ -116,8 +117,7 @@ export function getPredictedCost(userData: UserDataSelectType[], energyData: Sen
     const totalConsumptionCurrentMonth = getCalculatedTotalConsumptionCurrentMonth(energyData);
     const monthlyUsage: number = (totalConsumptionCurrentMonth / daysPassed) * lastDayOfMonth.getDate();
 
-    const predictedConsumption: number = monthlyUsage - totalConsumptionCurrentMonth;
-    return Number.parseFloat((predictedConsumption * price).toFixed(2));
+    return Number.parseFloat((monthlyUsage * workingPrice + basePrice).toFixed(2));
 }
 
 function getLatestUserData(userData: UserDataSelectType[]): UserDataSelectType {


### PR DESCRIPTION
So wie ich das sehe wurde hier nur BasePrice und WorkingPrice vertauscht, daher der hohe Wert.
Außerdem habe ich die Variable predictedConsumption entfernt, da es aus meiner Sicht keinen Sinn macht totalConsumptionCurrentMonth von monthlyUsage zu subtrahieren (in monthlyUsage ist der Verbrauch des aktuellen Monats dividiert durch die vergangenen Tage des Monate multipliziert mit der Gesamtzahl der Tage des Monats bereits enthalten). Prüft die Berechnung gerne nochmal nach. Denkt beim Ausführen und Testen daran keine eigenen Verbrauchswerte in der Zukunft zu erstellen, das würde die Summe der Hochrechnung negativ beeinflussen.