### PR TITLE
Peaks at least 5min apart

### DIFF
--- a/apps/web/src/app/(site)/dashboard/page.tsx
+++ b/apps/web/src/app/(site)/dashboard/page.tsx
@@ -40,9 +40,8 @@ export default async function DashboardPage({
     const aggregationType = searchParams.aggregation;
 
     const serverStart = new Date();
-    serverStart.setHours(0, 0, 0, 0);
+    serverStart.setHours(serverStart.getHours() - 3, 0, 0, 0);
     const serverEnd = new Date();
-    serverEnd.setHours(23, 59, 59, 999);
 
     const startDate = startDateString ? new Date(startDateString) : convertTZDate(serverStart);
     const endDate = endDateString ? new Date(endDateString) : convertTZDate(serverEnd);

--- a/packages/db/src/query/peaks.ts
+++ b/packages/db/src/query/peaks.ts
@@ -150,13 +150,10 @@ function findSequences(values: SensorDataSelectType[], threshold: number) {
                 // and only mark a new peak if at least 5min apart from previous
                 if (
                     sequences.length > 0 &&
-                    sequences[sequences.length - 1].end.getTime() - entry.timestamp.getTime() < 2 * 60 * 1000
+                    entry.timestamp.getTime() - sequences[sequences.length - 1].end.getTime() < 2 * 60 * 1000
                 ) {
                     sequences[sequences.length - 1].end = values[sequenceEnd - 1].timestamp;
-                } else if (
-                    sequences.length > 0 &&
-                    sequences[sequences.length - 1].end.getTime() - entry.timestamp.getTime() > 5 * 60 * 1000
-                ) {
+                } else {
                     sequences.push({
                         start: entry.timestamp,
                         end: values[sequenceEnd - 1].timestamp,

--- a/packages/db/src/query/peaks.ts
+++ b/packages/db/src/query/peaks.ts
@@ -263,7 +263,7 @@ export async function findAndMark(props: FindAndMarkPeaksProps, threshold = 5) {
                 averagePeakPower: d.averagePowerIncludingBaseLoad - baseLoad,
                 type,
                 sensorId,
-            }));
+            })).filter((d) => d.averagePeakPower > 0);
 
             if (props.type === "anomaly") {
                 // if it is anomaly make sure there at least 30min apart from previous ones to avoid double marking

--- a/packages/db/src/query/peaks.ts
+++ b/packages/db/src/query/peaks.ts
@@ -144,12 +144,20 @@ function findSequences(values: SensorDataSelectType[], threshold: number) {
             if (sequenceLength > 5) {
                 const avgPeakPower = calculateAveragePower(values.slice(i, sequenceEnd));
 
-                sequences.push({
-                    start: entry.timestamp,
-                    end: values[sequenceEnd - 1].timestamp,
-                    isAtStart: isStart,
-                    averagePowerIncludingBaseLoad: avgPeakPower,
-                });
+                // if sequences are only 5min apart, mark as one sequence, because could be of device variance
+                if (
+                    sequences.length > 0 &&
+                    sequences[sequences.length - 1].end.getTime() - entry.timestamp.getTime() < 5 * 60 * 1000
+                ) {
+                    sequences[sequences.length - 1].end = values[sequenceEnd - 1].timestamp;
+                } else {
+                    sequences.push({
+                        start: entry.timestamp,
+                        end: values[sequenceEnd - 1].timestamp,
+                        isAtStart: isStart,
+                        averagePowerIncludingBaseLoad: avgPeakPower,
+                    });
+                }
             }
             i = sequenceEnd;
         } else {

--- a/scripts/insert-energy-data.ts
+++ b/scripts/insert-energy-data.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { genId } from "@energyleaf/db";
-import { getRawEnergyForSensorInRange, insertRawEnergyValues } from "@energyleaf/db/query";
+import { findAndMark, getRawEnergyForSensorInRange, insertRawEnergyValues } from "@energyleaf/db/query";
 
 export async function insertEnergyData(args: string[]) {
     const sensorId = args[0];
@@ -44,7 +44,7 @@ export async function download(args: string[]) {
     const filePath = path.join(process.cwd(), "download.json");
 
     const start = new Date();
-    start.setDate(start.getDate() - 14);
+    start.setDate(start.getDate() - 19);
     start.setHours(0, 0, 0, 0);
 
     const end = new Date();
@@ -71,15 +71,47 @@ export async function upload(args: string[]) {
         timestamp: string;
     }[];
 
+    const processedData = data.map((d, i) => {
+        const totalBefore = data.slice(0, i).reduce((acc, d) => acc + d.value, 0);
+        const newDate = new Date(d.timestamp);
+        newDate.setDate(newDate.getDate() + 7);
+
+        return {
+            ...d,
+            value: i === 0 ? 0 : d.value + totalBefore,
+            valueCurrent: i === 0 ? 0 : d.valueCurrent,
+            valueOut: null,
+            timestamp: newDate,
+        };
+    });
+
     const splitSize = 1000;
-    for (let i = 0; i < data.length; i += splitSize) {
-        const chunk = data.slice(i, i + splitSize);
+    for (let i = 0; i < processedData.length; i += splitSize) {
+        const chunk = processedData.slice(i, i + splitSize);
         await insertRawEnergyValues(
             chunk.map((d) => ({
                 ...d,
                 sensorId,
-                timestamp: new Date(d.timestamp),
             })),
         );
     }
+}
+
+export async function markPeaks(args: string[]) {
+    const sensorId = args[0];
+    if (!sensorId) {
+        throw new Error("sensorId is required");
+    }
+
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - 10);
+    const endDate = new Date();
+    endDate.setDate(endDate.getDate() + 5);
+
+    await findAndMark({
+        start: startDate,
+        end: endDate,
+        sensorId,
+        type: "peak",
+    });
 }


### PR DESCRIPTION
Peaks müssen nun mindestens 5 Minuten voneinander entfernt sein. Dies verhindert, dass Peaks nur wenige Sekunden auseinanderliegen.

Des Weiteren werden Peaks, die weniger als 5 Minuten auseinanderliegen, als ein einzelner Peak markiert. Über dieses Intervall können wir noch diskutieren. Der Hintergrund ist, dass Geräte teilweise Schwankungen aufweisen und somit zwischenzeitlich unter den Schwellenwert fallen, wodurch diese fälschlicherweise als zwei separate Peaks gezählt bzw. gesplittet werden würden.

Die Standardansicht auf dem Dashboard zeigt nun die letzten 3 Stunden an. Auch hier können wir noch diskutieren. Ich persönlich finde es übersichtlicher als den ganzen Tag abzubilden und es verbessert die initiale Ladezeit.

## Update
Peaks werden jetzt kombiniert mit einer Toleranz von 2 Minuten.
Es muss weiterhin mindestens 5 Minuten Abstand zwischen Peaks geben.