### PR TITLE
Add jsdom as dependency in admin app

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -47,7 +47,8 @@
 		"recharts": "^2.12.7",
 		"server-only": "^0.0.1",
 		"sonner": "^1.5.0",
-		"zod": "^3.23.8"
+		"zod": "^3.23.8",
+		"jsdom": "^24.1.0"
 	},
 	"devDependencies": {
 		"@energyleaf/tsconfig": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       jose:
         specifier: ^5.4.0
         version: 5.4.1
+      jsdom:
+        specifier: ^24.1.0
+        version: 24.1.0(canvas@2.11.2)
       lucia:
         specifier: ^3.2.0
         version: 3.2.0


### PR DESCRIPTION
This fixes issues that the report endpoint returns an error.

Cherry-picked from: https://github.com/pgenergy/energyleaf/commit/e77eeaba9bd4703942f88ed5170fa3d81c679d48