### PR TITLE
Feature/pge 252 spar tipps geratekategorie hinzufugen

### DIFF
--- a/apps/web/src/app/(site)/dashboard/page.tsx
+++ b/apps/web/src/app/(site)/dashboard/page.tsx
@@ -64,20 +64,6 @@ export default async function DashboardPage({
                 <div className="col-span-1 md:col-span-3">
                     <h1 className="font-bold text-2xl">Übersicht</h1>
                 </div>
-                {fulfills(user.appVersion, Versions.support) && (
-                    <ErrorBoundary fallback={TipOfTheDayCardError}>
-                        <Suspense fallback={<Skeleton className="col-span-1 h-72 w-full md:col-span-3" />}>
-                            <TipOfTheDayCard />
-                        </Suspense>
-                    </ErrorBoundary>
-                )}
-                {fulfills(user.appVersion, Versions.self_reflection) && (
-                    <ErrorBoundary fallback={GoalsCardError}>
-                        <Suspense fallback={<Skeleton className="col-span-1 h-72 w-full md:col-span-3" />}>
-                            <GoalsCard />
-                        </Suspense>
-                    </ErrorBoundary>
-                )}
                 <Suspense fallback={<Skeleton className="h-40 w-full" />}>
                     <CurrentMeterNumberCard />
                 </Suspense>
@@ -87,6 +73,20 @@ export default async function DashboardPage({
                 <Suspense fallback={<Skeleton className="h-40 w-full" />}>
                     <CurrentMeterPowerCard />
                 </Suspense>
+                {fulfills(user.appVersion, Versions.self_reflection) && (
+                    <ErrorBoundary fallback={GoalsCardError}>
+                        <Suspense fallback={<Skeleton className="col-span-1 h-72 w-full md:col-span-3" />}>
+                            <GoalsCard />
+                        </Suspense>
+                    </ErrorBoundary>
+                )}
+                {fulfills(user.appVersion, Versions.support) && (
+                    <ErrorBoundary fallback={TipOfTheDayCardError}>
+                        <Suspense fallback={<Skeleton className="col-span-1 h-72 w-full md:col-span-3" />}>
+                            <TipOfTheDayCard />
+                        </Suspense>
+                    </ErrorBoundary>
+                )}
                 <div className="col-span-1 mt-8 flex flex-col gap-4 md:col-span-3 md:mt-16">
                     <h1 className="font-bold text-2xl">Werte im Zeitraum</h1>
                     <div className="flex flex-col gap-2 md:flex-row">

--- a/apps/web/src/components/dashboard/tip-of-the-day-card.tsx
+++ b/apps/web/src/components/dashboard/tip-of-the-day-card.tsx
@@ -1,7 +1,9 @@
 import { getSession } from "@/lib/auth/auth.server";
 import { getEnergyTipOfTheDay } from "@/query/recommendations";
-import { Card, CardContent, CardHeader, CardTitle } from "@energyleaf/ui/card";
+import { isDeviceCategory } from "@energyleaf/lib/tips";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@energyleaf/ui/card";
 import { LightbulbIcon } from "lucide-react";
+import DeviceCategoryIcon from "../devices/device-category-icon";
 import EnergyTipCardDescription from "../recommendations/tips/energy-tip-card-description";
 import EnergyTipText from "../recommendations/tips/energy-tip-text";
 
@@ -19,7 +21,12 @@ export default async function TipOfTheDayCard() {
                 <CardTitle className="flex flex-row gap-1">
                     Energiespartipp des Tages <LightbulbIcon className="text-primary" />
                 </CardTitle>
-                <EnergyTipCardDescription tip={energyTip} />
+                <CardDescription className="flex flex-row items-center gap-1">
+                    <EnergyTipCardDescription tip={energyTip} />
+                    {energyTip.belongsTo && isDeviceCategory(energyTip.belongsTo) ? (
+                        <DeviceCategoryIcon category={energyTip.belongsTo} className="h-5 w-5" />
+                    ) : null}
+                </CardDescription>
             </CardHeader>
             <CardContent className="items-center text-center text-xl italic">
                 <EnergyTipText tip={energyTip} />

--- a/apps/web/src/components/dashboard/tip-of-the-day-card.tsx
+++ b/apps/web/src/components/dashboard/tip-of-the-day-card.tsx
@@ -2,6 +2,7 @@ import { getSession } from "@/lib/auth/auth.server";
 import { getEnergyTipOfTheDay } from "@/query/recommendations";
 import { Card, CardContent, CardHeader, CardTitle } from "@energyleaf/ui/card";
 import { LightbulbIcon } from "lucide-react";
+import EnergyTipCardDescription from "../recommendations/tips/energy-tip-card-description";
 import EnergyTipText from "../recommendations/tips/energy-tip-text";
 
 export default async function TipOfTheDayCard() {
@@ -18,6 +19,7 @@ export default async function TipOfTheDayCard() {
                 <CardTitle className="flex flex-row gap-1">
                     Energiespartipp des Tages <LightbulbIcon className="text-primary" />
                 </CardTitle>
+                <EnergyTipCardDescription tip={energyTip} />
             </CardHeader>
             <CardContent className="items-center text-center text-xl italic">
                 <EnergyTipText tip={energyTip} />

--- a/apps/web/src/components/devices/device-category-icon.tsx
+++ b/apps/web/src/components/devices/device-category-icon.tsx
@@ -1,4 +1,5 @@
 import { DeviceCategory } from "@energyleaf/db/types";
+import { cn } from "@energyleaf/tailwindcss/utils";
 import {
     coffeemaker,
     dishwasher,
@@ -34,64 +35,66 @@ import VacuumCleaner from "./icons/vacuum-cleaner";
 
 interface Props {
     category: DeviceCategory;
+    className?: string;
 }
 
-export default function DeviceCategoryIcon({ category }: Props) {
+export default function DeviceCategoryIcon({ category, className }: Props) {
+    className = cn("h-6 w-6", className);
     switch (category) {
         case DeviceCategory.Stovetop:
-            return <Heater />;
+            return <Heater className={className} />;
         case DeviceCategory.Oven:
-            return <Oven />;
+            return <Oven className={className} />;
         case DeviceCategory.AirFryer:
-            return <Fryer />;
+            return <Fryer className={className} />;
         case DeviceCategory.Fridge:
-            return <Refrigerator />;
+            return <Refrigerator className={className} />;
         case DeviceCategory.Freezer:
-            return <Icon iconNode={refrigeratorFreezer} />;
+            return <Icon iconNode={refrigeratorFreezer} className={className} />;
         case DeviceCategory.Microwave:
-            return <Microwave />;
+            return <Microwave className={className} />;
         case DeviceCategory.Kettle:
-            return <Icon iconNode={kettleElectric} />;
+            return <Icon iconNode={kettleElectric} className={className} />;
         case DeviceCategory.Toaster:
-            return <Icon iconNode={toaster} />;
+            return <Icon iconNode={toaster} className={className} />;
         case DeviceCategory.CoffeeMachine:
-            return <Icon iconNode={coffeemaker} />;
+            return <Icon iconNode={coffeemaker} className={className} />;
         case DeviceCategory.Blender:
-            return <CookingPot />;
+            return <CookingPot className={className} />;
         case DeviceCategory.Dishwasher:
-            return <Icon iconNode={dishwasher} />;
+            return <Icon iconNode={dishwasher} className={className} />;
         case DeviceCategory.WashingMachine:
-            return <WashingMachine />;
+            return <WashingMachine className={className} />;
         case DeviceCategory.Dryer:
-            return <LaundryDryer />;
+            return <LaundryDryer className={className} />;
         case DeviceCategory.VacuumCleaner:
-            return <VacuumCleaner />;
+            return <VacuumCleaner className={className} />;
         case DeviceCategory.Iron:
-            return <Icon iconNode={iron} />;
+            return <Icon iconNode={iron} className={className} />;
         case DeviceCategory.TVsAndMonitors:
-            return <Tv />;
+            return <Tv className={className} />;
         case DeviceCategory.EntertainmentAndComputers:
-            return <Laptop />;
+            return <Laptop className={className} />;
         case DeviceCategory.HairDryer:
-            return <Icon iconNode={hairdryer} />;
+            return <Icon iconNode={hairdryer} className={className} />;
         case DeviceCategory.BodyCare:
-            return <Icon iconNode={razor} />;
+            return <Icon iconNode={razor} className={className} />;
         case DeviceCategory.HeaterFan:
-            return <Fan />;
+            return <Fan className={className} />;
         case DeviceCategory.ElectricHeater:
-            return <HeatingCoil />;
+            return <HeatingCoil className={className} />;
         case DeviceCategory.AirConditioning:
-            return <AirVent />;
+            return <AirVent className={className} />;
         case DeviceCategory.HeatPump:
-            return <HeatPump />;
+            return <HeatPump className={className} />;
         case DeviceCategory.Lighting:
-            return <Lamp />;
+            return <Lamp className={className} />;
         case DeviceCategory.ECar:
-            return <Car />;
+            return <Car className={className} />;
         case DeviceCategory.EMobility:
-            return <Bike />;
+            return <Bike className={className} />;
         case DeviceCategory.Others:
-            return <Ellipsis />;
+            return <Ellipsis className={className} />;
         default:
             return null;
     }

--- a/apps/web/src/components/devices/icons/fryer.tsx
+++ b/apps/web/src/components/devices/icons/fryer.tsx
@@ -1,3 +1,9 @@
-export default function Fryer() {
-    return <span className="icon-[mdi--oven]" style={{ width: "24px", height: "24px" }} />;
+import { cn } from "@energyleaf/tailwindcss/utils";
+
+interface Props {
+    className?: string;
+}
+
+export default function Fryer({ className }: Props) {
+    return <span className={cn("icon-[mdi--oven]", className)} />;
 }

--- a/apps/web/src/components/devices/icons/heat-pump.tsx
+++ b/apps/web/src/components/devices/icons/heat-pump.tsx
@@ -1,3 +1,9 @@
-export default function HeatPump() {
-    return <span className="icon-[material-symbols--heat-pump-outline]" style={{ width: "24px", height: "24px" }} />;
+import { cn } from "@energyleaf/tailwindcss/utils";
+
+interface Props {
+    className?: string;
+}
+
+export default function HeatPump({ className }: Props) {
+    return <span className={cn("icon-[material-symbols--heat-pump-outline]", className)} />;
 }

--- a/apps/web/src/components/devices/icons/heating-coil.tsx
+++ b/apps/web/src/components/devices/icons/heating-coil.tsx
@@ -1,3 +1,9 @@
-export default function HeatingCoil() {
-    return <span className="icon-[mdi--heating-coil]" style={{ width: "24px", height: "24px" }} />;
+import { cn } from "@energyleaf/tailwindcss/utils";
+
+interface Props {
+    className?: string;
+}
+
+export default function HeatingCoil({ className }: Props) {
+    return <span className={cn("icon-[mdi--heating-coil]", className)} />;
 }

--- a/apps/web/src/components/devices/icons/laundy-dryer.tsx
+++ b/apps/web/src/components/devices/icons/laundy-dryer.tsx
@@ -1,3 +1,9 @@
-export default function LaundryDryer() {
-    return <span className="icon-[ph--washing-machine]" style={{ width: "24px", height: "24px" }} />;
+import { cn } from "@energyleaf/tailwindcss/utils";
+
+interface Props {
+    className?: string;
+}
+
+export default function LaundryDryer({ className }: Props) {
+    return <span className={cn("icon-[ph--washing-machine]", className)} />;
 }

--- a/apps/web/src/components/devices/icons/oven.tsx
+++ b/apps/web/src/components/devices/icons/oven.tsx
@@ -1,5 +1,10 @@
+import { cn } from "@energyleaf/tailwindcss/utils";
 import React from "react";
 
-export default function Oven() {
-    return <span className="icon-[hugeicons--oven]" style={{ width: "24px", height: "24px" }} />;
+interface Props {
+    className?: string;
+}
+
+export default function Oven({ className }: Props) {
+    return <span className={cn("icon-[hugeicons--oven]", className)} />;
 }

--- a/apps/web/src/components/devices/icons/vacuum-cleaner.tsx
+++ b/apps/web/src/components/devices/icons/vacuum-cleaner.tsx
@@ -1,3 +1,9 @@
-export default function VacuumCleaner() {
-    return <span className="icon-[icon-park-outline--vacuum-cleaner]" style={{ width: "24px", height: "24px" }} />;
+import { cn } from "@energyleaf/tailwindcss/utils";
+
+interface Props {
+    className?: string;
+}
+
+export default function VacuumCleaner({ className }: Props) {
+    return <span className={cn("icon-[icon-park-outline--vacuum-cleaner]", className)} />;
 }

--- a/apps/web/src/components/recommendations/tips/energy-tip-card-description.tsx
+++ b/apps/web/src/components/recommendations/tips/energy-tip-card-description.tsx
@@ -1,0 +1,65 @@
+import DeviceCategoryIcon from "@/components/devices/device-category-icon";
+import {
+    DeviceCategory,
+    DeviceCategoryTitles,
+    DeviceSuperCategory,
+    DeviceSuperCategoryTitles,
+} from "@energyleaf/db/types";
+import type { EnergyTip } from "@energyleaf/lib/tips";
+import { CardDescription } from "@energyleaf/ui/card";
+import { useMemo } from "react";
+
+interface Props {
+    tip: EnergyTip;
+}
+
+export default function EnergyTipCardDescription({ tip }: Props) {
+    const { belongsTo } = tip;
+
+    const content = useMemo(() => {
+        if (!belongsTo) {
+            return "Allgemein";
+        }
+
+        function isDeviceCategory(
+            value: DeviceCategory | DeviceCategory[] | DeviceSuperCategory,
+        ): value is DeviceCategory {
+            return typeof value === "string" && Object.values(DeviceCategory).includes(value as DeviceCategory);
+        }
+
+        function isDeviceCategoryArray(
+            value: DeviceCategory | DeviceCategory[] | DeviceSuperCategory,
+        ): value is DeviceCategory[] {
+            return Array.isArray(value) && value.every(isDeviceCategory);
+        }
+
+        function isDeviceSuperCategory(
+            value: DeviceCategory | DeviceCategory[] | DeviceSuperCategory,
+        ): value is DeviceSuperCategory {
+            return (
+                typeof value === "string" && Object.values(DeviceSuperCategory).includes(value as DeviceSuperCategory)
+            );
+        }
+
+        if (isDeviceCategory(belongsTo)) {
+            return (
+                <span className="flex flex-row items-center gap-1">
+                    {`Für Geräte-Kategorie ${DeviceCategoryTitles[belongsTo]}`}
+                    <DeviceCategoryIcon category={belongsTo} />
+                </span>
+            );
+        }
+
+        if (isDeviceCategoryArray(belongsTo)) {
+            return `Für Geräte-Kategorien ${belongsTo.map((category) => DeviceCategoryTitles[category]).join(", ")}`;
+        }
+
+        if (isDeviceSuperCategory(belongsTo)) {
+            return `Für Geräte-Oberkategorie ${DeviceSuperCategoryTitles[belongsTo]}`;
+        }
+
+        return null;
+    }, [belongsTo]);
+
+    return <CardDescription>{content}</CardDescription>;
+}

--- a/apps/web/src/components/recommendations/tips/energy-tip-card-description.tsx
+++ b/apps/web/src/components/recommendations/tips/energy-tip-card-description.tsx
@@ -1,14 +1,6 @@
 "use client";
-
-import DeviceCategoryIcon from "@/components/devices/device-category-icon";
-import {
-    DeviceCategory,
-    DeviceCategoryTitles,
-    DeviceSuperCategory,
-    DeviceSuperCategoryTitles,
-} from "@energyleaf/db/types";
-import type { EnergyTip } from "@energyleaf/lib/tips";
-import { CardDescription } from "@energyleaf/ui/card";
+import { DeviceCategoryTitles, DeviceSuperCategoryTitles } from "@energyleaf/db/types";
+import { type EnergyTip, isDeviceCategory, isDeviceCategoryArray, isDeviceSuperCategory } from "@energyleaf/lib/tips";
 import { useMemo } from "react";
 
 interface Props {
@@ -22,33 +14,8 @@ export default function EnergyTipCardDescription({ tip }: Props) {
             return "Allgemein";
         }
 
-        function isDeviceCategory(
-            value: DeviceCategory | DeviceCategory[] | DeviceSuperCategory,
-        ): value is DeviceCategory {
-            return typeof value === "string" && Object.values(DeviceCategory).includes(value as DeviceCategory);
-        }
-
-        function isDeviceCategoryArray(
-            value: DeviceCategory | DeviceCategory[] | DeviceSuperCategory,
-        ): value is DeviceCategory[] {
-            return Array.isArray(value) && value.every(isDeviceCategory);
-        }
-
-        function isDeviceSuperCategory(
-            value: DeviceCategory | DeviceCategory[] | DeviceSuperCategory,
-        ): value is DeviceSuperCategory {
-            return (
-                typeof value === "string" && Object.values(DeviceSuperCategory).includes(value as DeviceSuperCategory)
-            );
-        }
-
         if (isDeviceCategory(belongsTo)) {
-            return (
-                <span className="flex flex-row items-center gap-1">
-                    {`Für Geräte-Kategorie ${DeviceCategoryTitles[belongsTo]}`}
-                    <DeviceCategoryIcon category={belongsTo} />
-                </span>
-            );
+            return `Für Geräte-Kategorie ${DeviceCategoryTitles[belongsTo]}`;
         }
 
         if (isDeviceCategoryArray(belongsTo)) {
@@ -62,5 +29,5 @@ export default function EnergyTipCardDescription({ tip }: Props) {
         return null;
     }, [tip]);
 
-    return <CardDescription>{content}</CardDescription>;
+    return content;
 }

--- a/apps/web/src/components/recommendations/tips/energy-tip-card-description.tsx
+++ b/apps/web/src/components/recommendations/tips/energy-tip-card-description.tsx
@@ -16,8 +16,6 @@ interface Props {
 }
 
 export default function EnergyTipCardDescription({ tip }: Props) {
-    console.log(tip);
-
     const content = useMemo(() => {
         const { belongsTo } = tip;
         if (!belongsTo) {

--- a/apps/web/src/components/recommendations/tips/energy-tip-card-description.tsx
+++ b/apps/web/src/components/recommendations/tips/energy-tip-card-description.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import DeviceCategoryIcon from "@/components/devices/device-category-icon";
 import {
     DeviceCategory,
@@ -14,9 +16,10 @@ interface Props {
 }
 
 export default function EnergyTipCardDescription({ tip }: Props) {
-    const { belongsTo } = tip;
+    console.log(tip);
 
     const content = useMemo(() => {
+        const { belongsTo } = tip;
         if (!belongsTo) {
             return "Allgemein";
         }
@@ -59,7 +62,7 @@ export default function EnergyTipCardDescription({ tip }: Props) {
         }
 
         return null;
-    }, [belongsTo]);
+    }, [tip]);
 
     return <CardDescription>{content}</CardDescription>;
 }

--- a/apps/web/src/components/recommendations/tips/energy-tip-random-picker.tsx
+++ b/apps/web/src/components/recommendations/tips/energy-tip-random-picker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import type { EnergyTip } from "@energyleaf/lib/tips";
+import DeviceCategoryIcon from "@/components/devices/device-category-icon";
+import { type EnergyTip, isDeviceCategory } from "@energyleaf/lib/tips";
 import { Button } from "@energyleaf/ui/button";
 import { ArrowRightIcon, LightbulbIcon } from "lucide-react";
 import EnergyTipText from "./energy-tip-text";
@@ -17,7 +18,11 @@ export default function EnergyTipRandomPicker({ onNextTip, tip }: Props) {
 
     return (
         <div className="flex flex-col items-center gap-4">
-            <LightbulbIcon className="h-16 w-16" />
+            {tip.belongsTo && isDeviceCategory(tip.belongsTo) ? (
+                <DeviceCategoryIcon category={tip.belongsTo} className="h-16 w-16" />
+            ) : (
+                <LightbulbIcon className="h-16 w-16" />
+            )}
             <EnergyTipText tip={tip} />
             <Button className="gap-2" onClick={onNextClick}>
                 Nächster Tipp <ArrowRightIcon />

--- a/apps/web/src/components/recommendations/tips/energy-tip-random-picker.tsx
+++ b/apps/web/src/components/recommendations/tips/energy-tip-random-picker.tsx
@@ -4,28 +4,23 @@ import type { EnergyTip } from "@energyleaf/lib/tips";
 import { Button } from "@energyleaf/ui/button";
 import {} from "@tanstack/react-query";
 import { ArrowRightIcon, LightbulbIcon } from "lucide-react";
-import { useState } from "react";
+import {} from "react";
 import EnergyTipText from "./energy-tip-text";
 
 interface Props {
-    tips: EnergyTip[];
+    onNextTip?: () => void;
+    tip: EnergyTip;
 }
 
-export default function EnergyTipRandomPicker({ tips }: Props) {
-    if (tips.length === 0) {
-        return <div className="flex flex-col items-center text-muted-foreground">Keine Tipps verfügbar.</div>;
-    }
-
-    const [tipIndex, setTipIndex] = useState<number>(0);
-
+export default function EnergyTipRandomPicker({ onNextTip, tip }: Props) {
     function onNextClick() {
-        setTipIndex((prev) => (prev + 1) % tips.length);
+        onNextTip?.();
     }
 
     return (
         <div className="flex flex-col items-center gap-4">
             <LightbulbIcon className="h-16 w-16" />
-            <EnergyTipText tip={tips[tipIndex]} />
+            <EnergyTipText tip={tip} />
             <Button className="gap-2" onClick={onNextClick}>
                 Nächster Tipp <ArrowRightIcon />
             </Button>

--- a/apps/web/src/components/recommendations/tips/energy-tip-random-picker.tsx
+++ b/apps/web/src/components/recommendations/tips/energy-tip-random-picker.tsx
@@ -2,9 +2,7 @@
 
 import type { EnergyTip } from "@energyleaf/lib/tips";
 import { Button } from "@energyleaf/ui/button";
-import {} from "@tanstack/react-query";
 import { ArrowRightIcon, LightbulbIcon } from "lucide-react";
-import {} from "react";
 import EnergyTipText from "./energy-tip-text";
 
 interface Props {

--- a/apps/web/src/components/recommendations/tips/energy-tips-card-content.tsx
+++ b/apps/web/src/components/recommendations/tips/energy-tips-card-content.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import type { EnergyTip } from "@energyleaf/lib/tips";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@energyleaf/ui/card";
+import { useState } from "react";
+import EnergyTipCardDescription from "./energy-tip-card-description";
+import EnergyTipRandomPicker from "./energy-tip-random-picker";
+
+interface Props {
+    tips: EnergyTip[];
+}
+
+export default function EnergyTipsCardContent({ tips }: Props) {
+    const [tipIndex, setTipIndex] = useState<number>(0);
+
+    function onNextClick() {
+        setTipIndex((prevIndex) => (prevIndex + 1) % tips.length);
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Energiespartipps</CardTitle>
+                <CardDescription>Hier erhalten Sie Tipps, um Strom zu sparen.</CardDescription>
+                <EnergyTipCardDescription tip={tips[tipIndex]} />
+            </CardHeader>
+            <CardContent>
+                {tips.length === 0 ? (
+                    <div className="flex flex-col items-center text-muted-foreground">Keine Tipps verfügbar.</div>
+                ) : (
+                    <EnergyTipRandomPicker tip={tips[tipIndex]} onNextTip={onNextClick} />
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/apps/web/src/components/recommendations/tips/energy-tips-card-content.tsx
+++ b/apps/web/src/components/recommendations/tips/energy-tips-card-content.tsx
@@ -21,8 +21,10 @@ export default function EnergyTipsCardContent({ tips }: Props) {
         <Card>
             <CardHeader>
                 <CardTitle>Energiespartipps</CardTitle>
-                <CardDescription>Hier erhalten Sie Tipps, um Strom zu sparen.</CardDescription>
-                <EnergyTipCardDescription tip={tips[tipIndex]} />
+                <CardDescription className="flex flex-col gap-1">
+                    <span>Hier erhalten Sie Tipps, um Strom zu sparen.</span>
+                    <EnergyTipCardDescription tip={tips[tipIndex]} />
+                </CardDescription>
             </CardHeader>
             <CardContent>
                 {tips.length === 0 ? (

--- a/apps/web/src/components/recommendations/tips/energy-tips-card.tsx
+++ b/apps/web/src/components/recommendations/tips/energy-tips-card.tsx
@@ -1,7 +1,5 @@
 import { getSession } from "@/lib/auth/auth.server";
 import { getEnergyTips } from "@/query/recommendations";
-import {} from "@energyleaf/ui/card";
-import {} from "lucide-react";
 import EnergyTipsCardContent from "./energy-tips-card-content";
 
 export default async function EnergyTipsCard() {

--- a/apps/web/src/components/recommendations/tips/energy-tips-card.tsx
+++ b/apps/web/src/components/recommendations/tips/energy-tips-card.tsx
@@ -1,9 +1,8 @@
 import { getSession } from "@/lib/auth/auth.server";
 import { getEnergyTips } from "@/query/recommendations";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@energyleaf/ui/card";
+import {} from "@energyleaf/ui/card";
 import {} from "lucide-react";
-import EnergyTipCardDescription from "./energy-tip-card-description";
-import EnergyTipRandomPicker from "./energy-tip-random-picker";
+import EnergyTipsCardContent from "./energy-tips-card-content";
 
 export default async function EnergyTipsCard() {
     const { user } = await getSession();
@@ -14,16 +13,5 @@ export default async function EnergyTipsCard() {
     const energyTips = await getEnergyTips(user.id);
     const shuffledTips = energyTips.sort(() => Math.random() - 0.5);
 
-    return (
-        <Card>
-            <CardHeader>
-                <CardTitle>Energiespartipps</CardTitle>
-                <CardDescription>Hier erhalten Sie Tipps, um Strom zu sparen.</CardDescription>
-                <EnergyTipCardDescription tip={shuffledTips[0]} />
-            </CardHeader>
-            <CardContent>
-                <EnergyTipRandomPicker tips={shuffledTips} />
-            </CardContent>
-        </Card>
-    );
+    return <EnergyTipsCardContent tips={shuffledTips} />;
 }

--- a/apps/web/src/components/recommendations/tips/energy-tips-card.tsx
+++ b/apps/web/src/components/recommendations/tips/energy-tips-card.tsx
@@ -2,6 +2,7 @@ import { getSession } from "@/lib/auth/auth.server";
 import { getEnergyTips } from "@/query/recommendations";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@energyleaf/ui/card";
 import {} from "lucide-react";
+import EnergyTipCardDescription from "./energy-tip-card-description";
 import EnergyTipRandomPicker from "./energy-tip-random-picker";
 
 export default async function EnergyTipsCard() {
@@ -18,6 +19,7 @@ export default async function EnergyTipsCard() {
             <CardHeader>
                 <CardTitle>Energiespartipps</CardTitle>
                 <CardDescription>Hier erhalten Sie Tipps, um Strom zu sparen.</CardDescription>
+                <EnergyTipCardDescription tip={shuffledTips[0]} />
             </CardHeader>
             <CardContent>
                 <EnergyTipRandomPicker tips={shuffledTips} />

--- a/packages/lib/src/recommendations/tips/energy-tip-belongs-to-guards.ts
+++ b/packages/lib/src/recommendations/tips/energy-tip-belongs-to-guards.ts
@@ -1,0 +1,19 @@
+import { DeviceCategory, DeviceSuperCategory } from "@energyleaf/db/types";
+
+export function isDeviceCategory(
+    value: DeviceCategory | DeviceCategory[] | DeviceSuperCategory,
+): value is DeviceCategory {
+    return typeof value === "string" && Object.values(DeviceCategory).includes(value as DeviceCategory);
+}
+
+export function isDeviceCategoryArray(
+    value: DeviceCategory | DeviceCategory[] | DeviceSuperCategory,
+): value is DeviceCategory[] {
+    return Array.isArray(value) && value.every(isDeviceCategory);
+}
+
+export function isDeviceSuperCategory(
+    value: DeviceCategory | DeviceCategory[] | DeviceSuperCategory,
+): value is DeviceSuperCategory {
+    return typeof value === "string" && Object.values(DeviceSuperCategory).includes(value as DeviceSuperCategory);
+}

--- a/packages/lib/src/recommendations/tips/energy-tip-definitions.ts
+++ b/packages/lib/src/recommendations/tips/energy-tip-definitions.ts
@@ -1,8 +1,10 @@
+import { DeviceCategory, DeviceSuperCategory } from "@energyleaf/db/types";
 import { EnergyTipKey } from "./energy-tip-key";
 
 export interface EnergyTip {
     text: string;
     linkToSource: string;
+    belongsTo?: DeviceCategory | DeviceCategory[] | DeviceSuperCategory;
 }
 
 export function getEnergyTip(tipKey: EnergyTipKey) {
@@ -13,384 +15,475 @@ const Tips: { [key in EnergyTipKey]: EnergyTip } = {
     [EnergyTipKey.StovetopLid]: {
         text: "Verwenden Sie einen Deckel beim Kochen. Wasserdampf im Topf ist genauso heiß wie das kochende Wasser am Topfboden.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.Stovetop,
     },
     [EnergyTipKey.StovetopAmountOfWater]: {
         text: "Verwenden Sie nur so viel Wasser zum Kochen von Gemüse, Kartoffeln oder Eiern, dass der Topfboden mit Wasser bedeckt ist.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.Stovetop,
     },
     [EnergyTipKey.StovetopReheat]: {
         text: "Schalten Sie Ihre Herdplatten frühzeitig ab und nutzen Sie die Platten-Nachhitze.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.Stovetop,
     },
     [EnergyTipKey.OvenConvection]: {
         text: "Die Umluftfunktion erlaubt das Absenken der Backtemperaturen bei gleicher oder geringerer Backdauer um bis zu 25 °C im Gegensatz zur Ober-/Unterhitze.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.Oven,
     },
     [EnergyTipKey.OvenPreventPreheat]: {
         text: "Normalerweise muss nicht vorgeheizt werden. Die Backdauer ist dann etwas länger, jedoch kann der Ofen einige Minuten vorher abgestellt werden, da die Restwärme genutzt werden kann.",
         linkToSource:
             "https://www.co2online.de/energie-sparen/strom-sparen/strom-sparen-stromspartipps/strom-sparen-tipps-und-tricks/",
+        belongsTo: DeviceCategory.Oven,
     },
     [EnergyTipKey.FridgeAndFreezerTemperature]: {
         text: "Beim Kühlschrank wird eine Innentemperatur von +7 °C und beim Gefrierschrank eine Temperatur von -18 °C empfohlen.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: [DeviceCategory.Fridge, DeviceCategory.Freezer],
     },
     [EnergyTipKey.FridgeAndFreezerStoreCovered]: {
         text: "Lagern Sie Lebensmittel nur abgedeckt, verpackt oder in Kunststoffbehältern, um das Bilden von Eisschichten zu verhindern.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: [DeviceCategory.Fridge, DeviceCategory.Freezer],
     },
     [EnergyTipKey.FridgeAndFreezerOpenBriefly]: {
         text: "Öffnen Sie Ihren Kühl- oder Gefrierschrank so kurz wie möglich. Eine übersichtliche Lagerung der Lebensmittel kann dabei helfen.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: [DeviceCategory.Fridge, DeviceCategory.Freezer],
     },
     [EnergyTipKey.FridgeAndFreezerOpenSeveralTimesForAShortTimeInsteadOfOnceForALongTime]: {
         text: "Es ist besser mehrmals hintereinander kurz den Kühl- oder Gefrierschrank zu öffnen, als ihn lange offen stehen zu lassen.",
         linkToSource:
             "https://www.co2online.de/energie-sparen/strom-sparen/strom-sparen-stromspartipps/strom-sparen-tipps-und-tricks/",
+        belongsTo: [DeviceCategory.Fridge, DeviceCategory.Freezer],
     },
     [EnergyTipKey.FridgeAndFreezerFull]: {
         text: "Je voller der Kühl- oder Gefrierschrank, desto weniger Kühlleistung muss das Gerät selbst erbringen.",
         linkToSource:
             "https://www.co2online.de/energie-sparen/strom-sparen/strom-sparen-stromspartipps/strom-sparen-tipps-und-tricks/",
+        belongsTo: [DeviceCategory.Fridge, DeviceCategory.Freezer],
     },
     [EnergyTipKey.FridgeNoHotObjects]: {
         text: "Stellen Sie keine heißen oder warmen Objekte in den Kühlschrank, dafür wird mehr Energie benötigt.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.Fridge,
     },
     [EnergyTipKey.FridgeDefrosting]: {
         text: "Tauen Sie Gefrorenes im Kühlschrank auf, denn die Kälte gefrorener Lebensmittel senkt die zum Kühlen benötigte Energie.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.Fridge,
     },
     [EnergyTipKey.MicrowaveRecommendedUse]: {
         text: "Nutzen Sie die Mikrowelle nur zum Erwärmen von kleineren Speisen bis zu 400 g.",
         linkToSource: "https://energiespartipps.de/strom-sparen-mikrowelle/",
+        belongsTo: DeviceCategory.Microwave,
     },
     [EnergyTipKey.MicrowaveCorrectPlacement]: {
         text: "Platzieren Sie die Gerichte möglichst flach und gleichmäßig auf dem Teller.",
         linkToSource: "https://energiespartipps.de/strom-sparen-mikrowelle/",
+        belongsTo: DeviceCategory.Microwave,
     },
     [EnergyTipKey.MicrowaveStandby]: {
         text: "Schalten Sie nach Nutzung den Standby-Modus an bzw. trennen Sie die Mikrowelle vom Stromnetz.",
         linkToSource: "https://energiespartipps.de/strom-sparen-mikrowelle/",
+        belongsTo: DeviceCategory.Microwave,
     },
     [EnergyTipKey.KettleFillWithNeededAmountOfWater]: {
         text: "Erhitzen Sie nur so viel Wasser, wie sie brauchen.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.Kettle,
     },
     [EnergyTipKey.KettleInComparisonToStovetop]: {
         text: "Im Vergleich zum Elektroherd verbraucht ein Wasserkocher ca. die Hälfte an Energie zum Erhitzen von einem halben Liter Wasser.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.Kettle,
     },
     [EnergyTipKey.CoffeeMachineHotplate]: {
         text: "Schalten Sie die Warmhalteplatte Ihrer Kaffeemaschine nach dem Brühen ab.",
         linkToSource: "https://www.plag-haustechnik.de/ueber-uns/nachhaltigkeit/ratgeber/kaffeemaschine",
+        belongsTo: DeviceCategory.CoffeeMachine,
     },
     [EnergyTipKey.CoffeeMachineTurnOffAfterUse]: {
         text: "Schalten Sie die Kaffeemaschine nach Gebrauch ab bzw. stellen Sie die  Abschaltautomatik auf eine geringe Betriebszeit ein.",
         linkToSource: "https://www.plag-haustechnik.de/ueber-uns/nachhaltigkeit/ratgeber/kaffeemaschine",
+        belongsTo: DeviceCategory.CoffeeMachine,
     },
     [EnergyTipKey.CoffeeMachineWithNeededAmountOfWater]: {
         text: "Füllen Sie den Wassertank nur mit etwas mehr als der benötigten Wassermenge.",
         linkToSource: "https://www.plag-haustechnik.de/ueber-uns/nachhaltigkeit/ratgeber/kaffeemaschine",
+        belongsTo: DeviceCategory.CoffeeMachine,
     },
     [EnergyTipKey.CoffeeMachineDescaling]: {
         text: "Entkalken Sie die Kaffeemaschine mindestens alle drei Monate.",
         linkToSource: "https://www.plag-haustechnik.de/ueber-uns/nachhaltigkeit/ratgeber/kaffeemaschine",
+        belongsTo: DeviceCategory.CoffeeMachine,
     },
     [EnergyTipKey.CoffeeMachineSteamNozzle]: {
         text: "Wenn Ihre Kaffeemaschine eine Dampfdüse besitzt, kann damit eine kleine Menge an Wasser erhitzt werden. Das ist energiesparender als mit dem Herd oder Wasserkocher.",
         linkToSource:
             "https://www.fuersie.de/lifestyle/haushalt-5-tipps-um-beim-kaffee-kochen-strom-zu-sparen-10743.html",
+        belongsTo: DeviceCategory.CoffeeMachine,
     },
     [EnergyTipKey.AirFryerPreheat]: {
         text: "Verzichten Sie vor dem Gebrauch der Heißluftfritteuse  auf Vorheizen.",
         linkToSource:
             "https://energie-echo.de/stromsparen-beim-frittieren-tipps-fuer-den-einsatz-der-hei-luftfritteuse/",
+        belongsTo: DeviceCategory.AirFryer,
     },
     [EnergyTipKey.AirFryerCutIntoSmallPieces]: {
         text: "Schneiden Sie Lebensmittel in kleinere Stücke, um die Zubereitungszeit zu verkürzen.",
         linkToSource:
             "https://energie-echo.de/stromsparen-beim-frittieren-tipps-fuer-den-einsatz-der-hei-luftfritteuse/",
+        belongsTo: DeviceCategory.AirFryer,
     },
     [EnergyTipKey.AirFryerSingleLayer]: {
         text: "Eine einzelne Schicht im Garkorb führt zu schnellem und gleichmäßigem Garen.",
         linkToSource:
             "https://energie-echo.de/stromsparen-beim-frittieren-tipps-fuer-den-einsatz-der-hei-luftfritteuse/",
+        belongsTo: DeviceCategory.AirFryer,
     },
     [EnergyTipKey.AirFryerIntermediateRaster]: {
         text: "Ein geeignetes Zwischenraster hilft die Kapazität zu erhöhen, ohne die Luftzirkulation zu behindern.",
         linkToSource:
             "https://energie-echo.de/stromsparen-beim-frittieren-tipps-fuer-den-einsatz-der-hei-luftfritteuse/",
+        belongsTo: DeviceCategory.AirFryer,
     },
     [EnergyTipKey.AirFryerSubsequentBatches]: {
         text: "Bereiten Sie mehrere Gerichte hintereinander zu, um die vorhandene Hitze effizient zu nutzen.",
         linkToSource:
             "https://energie-echo.de/stromsparen-beim-frittieren-tipps-fuer-den-einsatz-der-hei-luftfritteuse/",
+        belongsTo: DeviceCategory.AirFryer,
     },
     [EnergyTipKey.BlenderPreventIdleTime]: {
         text: "Vermeiden Sie Leerlaufzeiten und nutzen Sie den Mixer nur so lange wie nötig.",
         linkToSource: "https://solarwissen.selfmade-energy.com/wie-viel-strom-verbraucht-ein-handmixer/",
+        belongsTo: DeviceCategory.Blender,
     },
     [EnergyTipKey.BlenderAdjustSpeed]: {
         text: "Passen Sie die Geschwindigkeit und Intensität des Mixers nach Bedarf an.",
         linkToSource: "https://solarwissen.selfmade-energy.com/wie-viel-strom-verbraucht-ein-handmixer/",
+        belongsTo: DeviceCategory.Blender,
     },
     [EnergyTipKey.BlenderPreheatedIngredients]: {
         text: "Verwenden Sie vorgewärmte Zutaten, um die Mixzeit zu verkürzen.",
         linkToSource: "https://solarwissen.selfmade-energy.com/wie-viel-strom-verbraucht-ein-handmixer/",
+        belongsTo: DeviceCategory.Blender,
     },
     [EnergyTipKey.DishwasherFullLoad]: {
         text: "Spülmaschinen verbrauchen weniger Wasser als das Spülen von Hand, wenn sie voll beladen werden.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.Dishwasher,
     },
     [EnergyTipKey.DishwasherEcoProgram]: {
         text: "Eco-Programme sind effizienter und schonender. Ein Mal im Monat sollte bei 60 °C gespült werden, um Keimbildung zu verhindern.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.Dishwasher,
     },
     [EnergyTipKey.DishwasherPreRinse]: {
         text: "Grobe Essensreste können manuell entfernt werden, Vorspülen von Hand ist aber nicht nötig.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.Dishwasher,
     },
     [EnergyTipKey.WashingMachineFullLoad]: {
         text: "Waschen Sie nur, wenn Ihre Waschmaschine voll ist. Für kleine Haushalte lohnt sich die Verwendung kleinerer Waschmaschinen.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.WashingMachine,
     },
     [EnergyTipKey.WashingMachineLowTemperature]: {
         text: "Wenn Sie bei 30 °C waschen, wird nur ein Drittel des Stroms eines 60 °C-Waschgangs verbraucht.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.WashingMachine,
     },
     [EnergyTipKey.WashingMachineEcoProgram]: {
         text: "Eco-Programme senken die Temperatur und den Wasserverbrauch bei einer längeren Waschzeit.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.WashingMachine,
     },
     [EnergyTipKey.WashingMachineBoilWash]: {
         text: "Kochwäsche wird auch bei 60 °C sauber und bei stark verschmutzter Wäsche hilft ein Hygienespüler.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.WashingMachine,
     },
     [EnergyTipKey.WashingMachineTemperatureOnTextileLabels]: {
         text: "Textiletiketten zeigen nicht die empfohlene, sondern die maximal erlaubte Waschtemperatur.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.WashingMachine,
     },
     [EnergyTipKey.WashingMachinePreWash]: {
         text: "Nutzen Sie keine Vorwäsche vor der Hauptwäsche.",
         linkToSource:
             "https://www.co2online.de/energie-sparen/strom-sparen/strom-sparen-stromspartipps/strom-sparen-tipps-und-tricks/",
+        belongsTo: DeviceCategory.WashingMachine,
     },
     [EnergyTipKey.DryerDryInOpenAir]: {
         text: "Trocknen Sie Ihre Wäsche an der frischen Luft oder in unbeheizten, gut belüfteten Räumen.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceCategory.Dryer,
     },
     [EnergyTipKey.VacuumCleanerRemoveDisturbingObjects]: {
         text: "Räumen Sie vor dem Saugen störende Gegenstände aus dem Weg.",
         linkToSource: "https://www.plag-haustechnik.de/ueber-uns/nachhaltigkeit/ratgeber/staubsauger",
+        belongsTo: DeviceCategory.VacuumCleaner,
     },
     [EnergyTipKey.VacuumCleanerTurnOffWhenNotInUse]: {
         text: "Schalten Sie den Staubsauger aus, wenn Sie vom Saugen unterbrochen werden.",
         linkToSource: "https://www.plag-haustechnik.de/ueber-uns/nachhaltigkeit/ratgeber/staubsauger",
+        belongsTo: DeviceCategory.VacuumCleaner,
     },
     [EnergyTipKey.VacuumCleanerFullSuctionPowerOnlyForCarpet]: {
         text: "Nutzen Sie die volle Saugkraft nur für Teppiche. Für Fliesen, Parkett, usw. reicht eine niedrige Saugstufe.",
         linkToSource: "https://www.plag-haustechnik.de/ueber-uns/nachhaltigkeit/ratgeber/staubsauger",
+        belongsTo: DeviceCategory.VacuumCleaner,
     },
     [EnergyTipKey.VacuumCleanerEmptyRegularly]: {
         text: "Tauschen Sie den Staubsaugerbeutel regelmäßig aus Nutzen Sie bei Wegwerf-Beuteln die aus Vlies statt Papier.",
         linkToSource: "https://www.plag-haustechnik.de/ueber-uns/nachhaltigkeit/ratgeber/staubsauger",
+        belongsTo: DeviceCategory.VacuumCleaner,
     },
     [EnergyTipKey.VacuumCleanerChangeFilter]: {
         text: "Tauschen Sie alle zwei bis drei Monate den Filter Ihres Staubsaugers aus.",
         linkToSource: "https://www.plag-haustechnik.de/ueber-uns/nachhaltigkeit/ratgeber/staubsauger",
+        belongsTo: DeviceCategory.VacuumCleaner,
     },
     [EnergyTipKey.IronMoistenClothes]: {
         text: "Befeuchten Sie Kleidungsstücke durch Wassernebel aus der Sprühflasche statt mit Dampf. Alternativ können Sie ein dünnes angefeuchtetes Baumwolltuch auflegen.",
         linkToSource:
             "https://rp-online.de/leben/ratgeber/strom-sparen-beim-buegeln-so-buegelt-man-effizienter_aid-81412359",
+        belongsTo: DeviceCategory.Iron,
     },
     [EnergyTipKey.IronShortenTimeOrPrevent]: {
         text: "Verkürzen oder vermeiden Sie das Bügeln, indem Sie die Wäsche direkt aus der Trommel nehmen und hängend trocknen lassen – am besten mit einem glatten Gummibügel.",
         linkToSource:
             "https://rp-online.de/leben/ratgeber/strom-sparen-beim-buegeln-so-buegelt-man-effizienter_aid-81412359",
+        belongsTo: DeviceCategory.Iron,
     },
     [EnergyTipKey.IronMultipleClothes]: {
         text: "Bügeln Sie mehrere Artikel auf einmal.",
         linkToSource: "https://de.bluettipower.eu/blogs/sicherung-zu-hause/stromverbrauch-bugeleisen",
+        belongsTo: DeviceCategory.Iron,
     },
     [EnergyTipKey.IronTemperature]: {
         text: "Wählen Sie eine niedrigere Temperatur für empfindlichere Stoffe und eine höhere Temperatur für schwere Stoffe.",
         linkToSource: "https://de.bluettipower.eu/blogs/sicherung-zu-hause/stromverbrauch-bugeleisen",
+        belongsTo: DeviceCategory.Iron,
     },
     [EnergyTipKey.IronTurnOff]: {
         text: "Schalten Sie das Bügeleisen aus, wenn Sie eine Pause machen.",
         linkToSource: "https://de.bluettipower.eu/blogs/sicherung-zu-hause/stromverbrauch-bugeleisen",
+        belongsTo: DeviceCategory.Iron,
     },
     [EnergyTipKey.IronTypeOfWater]: {
         text: "Verwenden Sie destilliertes Wasser zum Bügeln.",
         linkToSource: "https://de.bluettipower.eu/blogs/sicherung-zu-hause/stromverbrauch-bugeleisen",
+        belongsTo: DeviceCategory.Iron,
     },
     [EnergyTipKey.EntertainmentDisconnectFromPowerSupply]: {
         text: "Selbst nach dem Abschalten verbrauchen viele Geräte Strom, da die innen liegenden Netzteile noch aktiv sind. Mit abschaltbaren Steckdosenleisten können die Geräte endgültig vom Stromnetz getrennt werden.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceSuperCategory.Entertainment,
     },
     [EnergyTipKey.EntertainmentStandby]: {
         text: "Stellen Sie Ihre elektronischen Geräte auf den Eco- oder Energiesparmodus ein. Oft ist es möglich, Geräte so einzustellen, dass sie nach kurzer Zeit der Nichtnutzung den Verbrauch reduzieren.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceSuperCategory.Entertainment,
     },
     [EnergyTipKey.EntertainmentLowerBrightness]: {
         text: "Senken Sie die Helligkeit Ihrer Bildschirme. Durch das Anpassen der Helligkeit an die Lichtverhältnisse kann der Stromverbrauch um über 50% reduziert werden.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceSuperCategory.Entertainment,
     },
     [EnergyTipKey.EntertainmentTurnOffDisplay]: {
         text: "Schalten Sie zumindest den Bildschirm aus, wenn Sie eine Pause machen.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceSuperCategory.Entertainment,
     },
     [EnergyTipKey.TVsAndMonitorsSizeAndEquipment]: {
         text: "Je größer der Bildschirm und je umfangreicher die Ausstattung, desto mehr Strom benötigt der Fernseher.",
         linkToSource:
             "https://www.co2online.de/energie-sparen/strom-sparen/strom-sparen-stromspartipps/strom-sparen-tipps-und-tricks/",
+        belongsTo: DeviceCategory.TVsAndMonitors,
     },
     [EnergyTipKey.TVsAndMonitorsPreferLED]: {
         text: "Plasma-Bildschirme haben einen höheren Verbrauch als Geräte mit LED-Hintergrundbeleuchtung.",
         linkToSource:
             "https://www.co2online.de/energie-sparen/strom-sparen/strom-sparen-stromspartipps/strom-sparen-tipps-und-tricks/",
+        belongsTo: DeviceCategory.TVsAndMonitors,
     },
     [EnergyTipKey.EntertainmentAndComputersConsumptionPerDevice]: {
         text: "Laptops verbrauchen weniger Energie als Desktop-PCs. Tablets oder Smartphones verbrauchen weniger Strom als Laptops.",
         linkToSource:
             "https://www.co2online.de/energie-sparen/strom-sparen/strom-sparen-stromspartipps/strom-sparen-tipps-und-tricks/",
+        belongsTo: DeviceCategory.EntertainmentAndComputers,
     },
     [EnergyTipKey.EntertainmentAndComputersShutdownInsteadOfStandby]: {
         text: "Schalten Sie Elektrogeräte nach dem Gebrauch nicht in den Standby-Modus, sondern komplett aus.",
         linkToSource:
             "https://www.co2online.de/energie-sparen/strom-sparen/strom-sparen-stromspartipps/strom-sparen-tipps-und-tricks/",
+        belongsTo: DeviceCategory.EntertainmentAndComputers,
     },
     [EnergyTipKey.EntertainmentAndComputersUnplugChargers]: {
         text: "Ziehen Sie Ladegeräte nach dem Laden aus der Steckdose, sonst fließt weiter Strom.",
         linkToSource:
             "https://www.co2online.de/energie-sparen/strom-sparen/strom-sparen-stromspartipps/strom-sparen-tipps-und-tricks/",
+        belongsTo: DeviceCategory.EntertainmentAndComputers,
     },
     [EnergyTipKey.HairDryerSqueezeMoistureOutOfHair]: {
         text: "Drücken Sie die Feuchtigkeit vor dem Föhnen aus den Haaren.",
         linkToSource: "https://utopia.de/ratgeber/haare-foehnen-so-sparst-du-dabei-strom_252947/",
+        belongsTo: DeviceCategory.HairDryer,
     },
     [EnergyTipKey.HairDryerPreDryHair]: {
         text: "Lassen Sie Ihre Haare an der Luft vortrocknen.",
         linkToSource: "https://utopia.de/ratgeber/haare-foehnen-so-sparst-du-dabei-strom_252947/",
+        belongsTo: DeviceCategory.HairDryer,
     },
     [EnergyTipKey.HairDryerShortUsage]: {
         text: "Föhnen Sie Ihre Haare nur kurz an.",
         linkToSource: "https://utopia.de/ratgeber/haare-foehnen-so-sparst-du-dabei-strom_252947/",
+        belongsTo: DeviceCategory.HairDryer,
     },
     [EnergyTipKey.HairDryerLowStage]: {
         text: "Verwenden Sie eine niedrige Föhnstufe.",
         linkToSource: "https://utopia.de/ratgeber/haare-foehnen-so-sparst-du-dabei-strom_252947/",
+        belongsTo: DeviceCategory.HairDryer,
     },
     [EnergyTipKey.ClimateControlRecommendedTemperature]: {
         text: "Empfohlen werden Temperaturen von 20 - 22 °C im Wohnzimmer, 17 - 18 °C im Schlafzimmer und 22 °C im Badezimmer.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceSuperCategory.ClimateControl,
     },
     [EnergyTipKey.ClimateControlVentilation]: {
         text: "Lüften Sie 3 - 4 am Tag für jeweils 5 - 10 Minuten. Stoßlüften mit weit geöffnetem Fenster oder Querlüften mit weit geöffneten gegenüberliegenden Fenstern und Innentüren sind geeignet.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceSuperCategory.ClimateControl,
     },
     [EnergyTipKey.ClimateControlRecommendedPlacement]: {
         text: "Heizkörper und Thermostatventile sollen frei stehen, damit Wärme optimal in den Raum abgegeben werden kann.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceSuperCategory.ClimateControl,
     },
     [EnergyTipKey.ClimateControlLowerTemperatureInNight]: {
         text: "Drehen Sie nachts die Heizung auf 15 - 16 °C runter.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceSuperCategory.ClimateControl,
     },
     [EnergyTipKey.ClimateControlDoNotHeatDuringVentilation]: {
         text: "Schließen Sie während des Lüftens immer die Thermostatventile der Heizkörper.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceSuperCategory.ClimateControl,
     },
     [EnergyTipKey.ClimateControlVentilationAtHighHumidity]: {
         text: "Lüften Sie immer direkt, wenn nach dem Duschen, Kochen oder Bodenwischen hohe Feuchtemengen entstehen.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceSuperCategory.ClimateControl,
     },
     [EnergyTipKey.ClimateControlLowerHeatingPumpOrReplace]: {
         text: "Stellen Sie Ihre Heizungspumpe niedriger oder tauschen Sie sie aus.",
         linkToSource:
             "https://www.co2online.de/energie-sparen/strom-sparen/strom-sparen-stromspartipps/strom-sparen-tipps-und-tricks/",
+        belongsTo: DeviceSuperCategory.ClimateControl,
     },
     [EnergyTipKey.ClimateControlRegularlyVentRadiators]: {
         text: "Entlüften Sie Heizkörper regelmäßig.",
         linkToSource: "https://verbraucherzentrale-energieberatung.de/energie-sparen/",
+        belongsTo: DeviceSuperCategory.ClimateControl,
     },
     [EnergyTipKey.LightingTurnOffWhenNotInUse]: {
         text: "Das Ein- und Ausschalten von Licht führt zu keinem höheren Stromverbrauch oder reduzierten Lebensdauer von LED-Lampen. Schalten Sie das Licht immer aus, wenn Sie den Raum verlassen.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceSuperCategory.Lighting,
     },
     [EnergyTipKey.LightingUseDaylight]: {
         text: "Nutzen Sie wenn möglich Tageslicht.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceSuperCategory.Lighting,
     },
     [EnergyTipKey.LightingUseOnlyForNecessaryAreas]: {
         text: "Beleuchten Sie nur die Bereiche, in denen viel Licht benötigt wird.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceSuperCategory.Lighting,
     },
     [EnergyTipKey.LightingUseLED]: {
         text: "Ersetzen Sie ineffiziente Lampen durch LED-Beleuchtung.",
         linkToSource: "https://www.stromspar-check.de/energiespartipps",
+        belongsTo: DeviceSuperCategory.Lighting,
     },
     [EnergyTipKey.ECarDriveEconomically]: {
         text: "Fahren Sie mit Ihrem Auto vorausschauend und sparsam.",
         linkToSource: "https://www.polarstern-energie.de/magazin/artikel/elektroauto-strom-energie-sparen-fahren/",
+        belongsTo: DeviceCategory.ECar,
     },
     [EnergyTipKey.ECarRecuperation]: {
         text: "Nutzen Sie den Rekuperationseffekt beim Elektroauto, indem Sie die Motorbremse wirken lassen.",
         linkToSource: "https://www.polarstern-energie.de/magazin/artikel/elektroauto-strom-energie-sparen-fahren/",
+        belongsTo: DeviceCategory.ECar,
     },
     [EnergyTipKey.ECarEcoMode]: {
         text: "Verwenden Sie den Eco- oder Energiesparmodus Ihres Elektroautos.",
         linkToSource: "https://www.polarstern-energie.de/magazin/artikel/elektroauto-strom-energie-sparen-fahren/",
+        belongsTo: DeviceCategory.ECar,
     },
     [EnergyTipKey.ECarDoNotDriveWithUnnecessaryWeight]: {
         text: "Fahren Sie nicht mit einem unnötig beladenem Auto.",
         linkToSource: "https://www.polarstern-energie.de/magazin/artikel/elektroauto-strom-energie-sparen-fahren/",
+        belongsTo: DeviceCategory.ECar,
     },
     [EnergyTipKey.ECarAccelerateSlowly]: {
         text: "Beschleunigen Sie sanft.",
         linkToSource: "https://www.polarstern-energie.de/magazin/artikel/elektroauto-strom-energie-sparen-fahren/",
+        belongsTo: DeviceCategory.ECar,
     },
     [EnergyTipKey.ECarRollOut]: {
         text: "Lassen Sie Ihr Elektroauto ausrollen.",
         linkToSource: "https://www.polarstern-energie.de/magazin/artikel/elektroauto-strom-energie-sparen-fahren/",
+        belongsTo: DeviceCategory.ECar,
     },
     [EnergyTipKey.ECarReduceAcclimatization]: {
         text: "Reduzieren Sie die Heizleistung in Ihrem Elektroauto, um die Reichweite zu erhöhen.",
         linkToSource: "https://www.polarstern-energie.de/magazin/artikel/elektroauto-strom-energie-sparen-fahren/",
+        belongsTo: DeviceCategory.ECar,
     },
     [EnergyTipKey.ECarRegularlyCheckTirePressure]: {
         text: "Prüfen Sie regelmäßig Ihren Reifendruck, um den Rollwiderstand zu reduzieren.",
         linkToSource: "https://www.polarstern-energie.de/magazin/artikel/elektroauto-strom-energie-sparen-fahren/",
+        belongsTo: DeviceCategory.ECar,
     },
     [EnergyTipKey.ECarDriveFlatRoutes]: {
         text: "Wählen Sie möglichst flache Strecken.",
         linkToSource: "https://www.polarstern-energie.de/magazin/artikel/elektroauto-strom-energie-sparen-fahren/",
+        belongsTo: DeviceCategory.ECar,
     },
     [EnergyTipKey.ECarUseElectronicOnlyWhenNeeded]: {
         text: "Schalten Sie Abblendlicht, Radio, Klimaanlage, Sitzheizung, Nebelscheinwerfer und Innenbeleuchtung nur an, wenn Sie sie brauchen.",
         linkToSource: "https://www.polarstern-energie.de/magazin/artikel/elektroauto-strom-energie-sparen-fahren/",
+        belongsTo: DeviceCategory.ECar,
     },
     [EnergyTipKey.EMobilitySteadyCadence]: {
         text: "Achten Sie beim E-Bike auf eine stetige Trittfrequenz von 70 - 75 Umdrehungen pro Minute.",
         linkToSource: "https://fit-ebike.com/ueber-uns/blog/e-bike-akku-reichweite-erhoehen/",
+        belongsTo: DeviceCategory.EMobility,
     },
     [EnergyTipKey.EMobilityAsLittleSupportAsPossible]: {
         text: "Je geringer die Unterstützungsstufe beim E-Bike, desto weniger Akku wird benötigt.",
         linkToSource: "https://fit-ebike.com/ueber-uns/blog/e-bike-akku-reichweite-erhoehen/",
+        belongsTo: DeviceCategory.EMobility,
     },
     [EnergyTipKey.EMobilityPreventStops]: {
         text: "Versuchen Sie mit Ihrem Elektrofahrzeug so wenig wie möglich zu stoppen, indem Sie langsam auf eine Ampel zurollen oder abrupte Geschwindigkeitswechsel vermeiden.",
         linkToSource: "https://fit-ebike.com/ueber-uns/blog/e-bike-akku-reichweite-erhoehen/",
+        belongsTo: DeviceCategory.EMobility,
     },
     [EnergyTipKey.EMobilityCheckRegularly]: {
         text: "Warten Sie Ihr Elektrofahrzeug regelmäßig und prüfen Sie ggf. den Reifendruck.",
         linkToSource: "https://fit-ebike.com/ueber-uns/blog/e-bike-akku-reichweite-erhoehen/",
+        belongsTo: DeviceCategory.EMobility,
     },
     [EnergyTipKey.EMobilityDriveFlatRoutes]: {
         text: "Wählen Sie für Ihr Elektrofahrzeug möglichst flache Routen, um eine größere Reichweite zu erreichen.",
         linkToSource: "https://fit-ebike.com/ueber-uns/blog/e-bike-akku-reichweite-erhoehen/",
+        belongsTo: DeviceCategory.EMobility,
     },
     [EnergyTipKey.CommonElectricWarmWaterLowerWaterUsage]: {
         text: "Wird Ihr Wasser elektrisch erwärmt, sparen Sie Strom, indem Sie Ihren Warmwasserverbrauch reduzieren. Wenn Sie in unter 10 min Duschen, sparen Sie dadurch mehr Wasser als beim Baden.",

--- a/packages/lib/src/recommendations/tips/index.ts
+++ b/packages/lib/src/recommendations/tips/index.ts
@@ -1,3 +1,4 @@
 export * from "./energy-tips";
 export { getEnergyTip } from "./energy-tip-definitions";
 export type { EnergyTip } from "./energy-tip-definitions";
+export * from "./energy-tip-belongs-to-guards";


### PR DESCRIPTION
## Changelog
- Bei den Energiespartipps wird nun die Geräte-Kategorie angezeigt.
- Reihenfolge in Dashboard geändert
-- Erst Aktueller Zählerstand usw.
-- Dann Ziele
-- Dann Tipp des Tages

## Screenshots
![image](https://github.com/user-attachments/assets/19b2730a-e4f5-4e27-af93-c6c6f8bc6aae)
![Bildschirmfoto vom 2024-07-30 14-59-32](https://github.com/user-attachments/assets/2dbb62ee-93eb-406c-9597-a93f9a9047ec)
![Bildschirmfoto vom 2024-07-30 14-59-23](https://github.com/user-attachments/assets/ee5517ef-e299-42d2-9aed-48b467203efc)
![image](https://github.com/user-attachments/assets/2d3e5001-49f7-47f0-9dc0-ec152e323129)

