### PR TITLE
Demo Performance

### DIFF
--- a/apps/web/src/lib/demo/demo.ts
+++ b/apps/web/src/lib/demo/demo.ts
@@ -1,5 +1,5 @@
 import { findPeaks } from "@energyleaf/db/query";
-import { getEnergyLastEntry, getRawEnergyForSensorInRange } from "@energyleaf/db/query";
+import { getEnergyForSensorInRange, getEnergyLastEntry } from "@energyleaf/db/query";
 import {
     DeviceCategory,
     type DeviceSelectType,
@@ -8,8 +8,8 @@ import {
     type SensorDeviceSequenceSelectType,
     type UserDataType,
 } from "@energyleaf/db/types";
-import { AggregationType, type ReportProps, convertTZDate } from "@energyleaf/lib";
-import { differenceInDays, getWeekOfMonth, getWeekYear } from "date-fns";
+import { AggregationType, type ReportProps } from "@energyleaf/lib";
+import { differenceInDays } from "date-fns";
 import { type MathNumericType, type Matrix, all, create } from "mathjs";
 import type { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
 import { cookies } from "next/headers";
@@ -322,24 +322,20 @@ export async function updateDemoPowerEstimationForDevices(cookies: ReadonlyReque
     return;
 }
 
-async function getDemoSensorCachedData(): Promise<SensorDataSelectType[]> {
-    const inputData = await getRawEnergyForSensorInRange(new Date(0), new Date(), "demo_sensor");
-
+function processDemoDataDate(data: SensorDataSelectType[]): SensorDataSelectType[] {
     const current = new Date();
-    const lastEntry = inputData[inputData.length - 1];
-    const dayDiff = differenceInDays(current, new Date(lastEntry.timestamp));
+    const lastEntry = data[data.length - 1];
+    const dayDiff = differenceInDays(current, lastEntry.timestamp);
 
-    const processedData = inputData
-        .map((item) => {
-            const dataDate = new Date(item.timestamp);
-            dataDate.setDate(dataDate.getDate() + dayDiff + 1);
+    const processedData = data.map((item) => {
+        const dataDate = new Date(item.timestamp);
+        dataDate.setDate(dataDate.getDate() + dayDiff + 1);
 
-            return {
-                ...item,
-                timestamp: dataDate,
-            };
-        })
-        .slice(1);
+        return {
+            ...item,
+            timestamp: dataDate,
+        };
+    });
 
     return processedData;
 }
@@ -348,135 +344,24 @@ export async function getDemoSensorData(
     start: Date,
     end: Date,
     agg?: AggregationType,
+    type: "sum" | "average" = "average",
 ): Promise<SensorDataSelectType[]> {
-    const data = await getDemoSensorCachedData();
-    const dataInRange = data.filter(
-        (item) => item.timestamp.getTime() >= start.getTime() && item.timestamp.getTime() <= end.getTime(),
-    );
-
-    const result: SensorDataSelectType[] = [];
-    switch (agg) {
-        case AggregationType.RAW:
-            return dataInRange;
-        case AggregationType.HOUR:
-            for (let i = 0; i < dataInRange.length; i++) {
-                const item = dataInRange[i];
-                const index = result.findIndex(
-                    (d) =>
-                        convertTZDate(d.timestamp, "client").getHours() ===
-                        convertTZDate(item.timestamp, "client").getHours(),
-                );
-
-                if (index === -1) {
-                    result.push(item);
-                } else {
-                    result[index].value += item.value;
-                }
-            }
-            return result;
-        case AggregationType.DAY:
-            for (let i = 0; i < dataInRange.length; i++) {
-                const item = dataInRange[i];
-                const index = result.findIndex(
-                    (d) =>
-                        convertTZDate(d.timestamp, "client").getDate() ===
-                        convertTZDate(item.timestamp, "client").getDate(),
-                );
-
-                if (index === -1) {
-                    result.push(item);
-                } else {
-                    result[index].value += item.value;
-                }
-            }
-            return result;
-        case AggregationType.WEEKDAY:
-            for (let i = 0; i < dataInRange.length; i++) {
-                const item = dataInRange[i];
-                const index = result.findIndex(
-                    (d) =>
-                        convertTZDate(d.timestamp, "client").getDay() ===
-                        convertTZDate(item.timestamp, "client").getDay(),
-                );
-
-                if (index === -1) {
-                    result.push(item);
-                } else {
-                    result[index].value += item.value;
-                }
-            }
-            return result;
-        case AggregationType.WEEK:
-            for (let i = 0; i < dataInRange.length; i++) {
-                const item = dataInRange[i];
-                const index = result.findIndex(
-                    (d) =>
-                        getWeekOfMonth(convertTZDate(d.timestamp, "client")) ===
-                        getWeekOfMonth(convertTZDate(item.timestamp, "client")),
-                );
-
-                if (index === -1) {
-                    result.push(item);
-                } else {
-                    result[index].value += item.value;
-                }
-            }
-            return result;
-        case AggregationType.CALENDAR_WEEK:
-            for (let i = 0; i < dataInRange.length; i++) {
-                const item = dataInRange[i];
-                const index = result.findIndex(
-                    (d) =>
-                        getWeekYear(convertTZDate(d.timestamp, "client")) ===
-                        getWeekYear(convertTZDate(item.timestamp, "client")),
-                );
-
-                if (index === -1) {
-                    result.push(item);
-                } else {
-                    result[index].value += item.value;
-                }
-            }
-            return result;
-        case AggregationType.MONTH:
-            for (let i = 0; i < dataInRange.length; i++) {
-                const item = dataInRange[i];
-                const index = result.findIndex(
-                    (d) =>
-                        convertTZDate(d.timestamp, "client").getMonth() ===
-                        convertTZDate(item.timestamp, "client").getMonth(),
-                );
-
-                if (index === -1) {
-                    result.push(item);
-                } else {
-                    result[index].value += item.value;
-                }
-            }
-            return result;
-        case AggregationType.YEAR:
-            for (let i = 0; i < dataInRange.length; i++) {
-                const item = dataInRange[i];
-                const index = result.findIndex(
-                    (d) =>
-                        convertTZDate(d.timestamp, "client").getFullYear() ===
-                        convertTZDate(item.timestamp, "client").getFullYear(),
-                );
-
-                if (index === -1) {
-                    result.push(item);
-                } else {
-                    result[index].value += item.value;
-                }
-            }
-            return result;
-        default:
-            return dataInRange;
+    const lastEntry = await getDemoLastEnergyEntry();
+    if (!lastEntry) {
+        return [];
     }
+    const dayDiff = differenceInDays(new Date(), lastEntry.timestamp) + 1;
+    const queryStart = new Date(start);
+    queryStart.setDate(queryStart.getDate() - dayDiff);
+    const queryEnd = new Date(end);
+    queryEnd.setDate(queryEnd.getDate() - dayDiff);
+
+    const data = await getEnergyForSensorInRange(queryStart, queryEnd, "demo_sensor", agg, type);
+    return processDemoDataDate(data);
 }
 
 export async function getDemoPeaks(start: Date, end: Date): Promise<SensorDataSequenceType[]> {
-    const data = await getDemoSensorCachedData();
+    const data = await getDemoSensorData(start, end, AggregationType.RAW);
 
     const peaks = findPeaks(data, data);
     const dataWithoutPeaks = data.filter(
@@ -526,11 +411,7 @@ export async function getDemoPeaks(start: Date, end: Date): Promise<SensorDataSe
         }));
 }
 
-export async function getDemoLastEnergyEntry(): Promise<{
-    value: number;
-    valueOut: number | null;
-    valueCurrent: number | null;
-} | null> {
+export async function getDemoLastEnergyEntry() {
     const inputData = await getEnergyLastEntry("demo_sensor");
     return inputData;
 }

--- a/apps/web/src/query/energy.ts
+++ b/apps/web/src/query/energy.ts
@@ -32,7 +32,7 @@ export const getAvgEnergyConsumptionForSensor = cache(async (sensorId: string) =
     if (sensorId === "demo_sensor") {
         const demoStart = new Date(new Date().setHours(0, 0, 0, 0));
         const demoEnd = new Date(new Date().setHours(23, 59, 59, 999));
-        const data = getDemoSensorData(demoStart, demoEnd);
+        const data = await getDemoSensorData(demoStart, demoEnd);
         return data.reduce((acc, cur) => acc + cur.value, 0) / data.length;
     }
     return getDbAvgEnergyConsumptionForSensor(sensorId);
@@ -42,7 +42,7 @@ export const getAvgEnergyConsumptionForUserInComparison = cache(async (userId: s
     if (userId === "demo") {
         const demoStart = new Date(new Date().setHours(0, 0, 0, 0));
         const demoEnd = new Date(new Date().setHours(23, 59, 59, 999));
-        const data = getDemoSensorData(demoStart, demoEnd);
+        const data = await getDemoSensorData(demoStart, demoEnd);
         const avg = data.reduce((acc, cur) => acc + cur.value, 0) / data.length;
         const count = data.length;
         return { avg, count };

--- a/apps/web/src/query/energy.ts
+++ b/apps/web/src/query/energy.ts
@@ -22,7 +22,7 @@ export const getEnergyDataForSensor = cache(
         const start = new Date(startDate);
         const end = new Date(endDate);
         if (sensorId === "demo_sensor") {
-            return getDemoSensorData(start, end, aggregation);
+            return getDemoSensorData(start, end, aggregation, aggType);
         }
         return getDbEnergyForSensorInRange(start, end, sensorId, aggregation, aggType);
     },

--- a/packages/db/src/query/sensor.ts
+++ b/packages/db/src/query/sensor.ts
@@ -317,6 +317,7 @@ export async function getEnergyLastEntry(sensorId: string) {
             value: sensorData.value,
             valueOut: sensorData.valueOut,
             valueCurrent: sensorData.valueCurrent,
+            timestamp: sensorData.timestamp,
         })
         .from(sensorData)
         .where(eq(sensorData.sensorId, sensorId))


### PR DESCRIPTION
Aktuell ist es so, dass die Demo Daten in einer JSON vom Server gelanden werden. Dies sorgt nicht nur für unglaubliche IO Kosten sondern auch das die Seite extrem lange lädt.

Wir hätten die Möglichkeit die Daten zu verkleinern und weniger Daten anzuzeigen. Ich habe mich dafür entschieden die Demo Daten ebenfalls auf die Datenbank zu legen und die Berechnung dort zu machen.

## Todo
- [x] Daten in Main
- [x] Daten in Dev