### PR TITLE
Bugfix/peaks duplicate key error

### DIFF
--- a/apps/admin/src/app/(api)/api/v1/process_peaks/route.ts
+++ b/apps/admin/src/app/(api)/api/v1/process_peaks/route.ts
@@ -49,7 +49,7 @@ const fn = async (sensorId: string) => {
                 }),
             );
 
-            classifyAndSaveDevicesForPeaks(peaksToClassify, user.userId);
+            await classifyAndSaveDevicesForPeaks(peaksToClassify, user.userId);
         }
     } catch (err) {
         logError(

--- a/apps/web/src/app/(site)/reports/[id]/layout.tsx
+++ b/apps/web/src/app/(site)/reports/[id]/layout.tsx
@@ -53,7 +53,9 @@ export default async function ReportsPageLayout({ children, params }: Props) {
 
     const toDate = convertTZDate(report.dateTo);
     const fromDate = convertTZDate(report.dateFrom);
-    const reportHasMoreThanOneDay = !(differenceInDays(convertTZDate(toDate, "client"), convertTZDate(fromDate, "client")) === 1);
+    const reportHasMoreThanOneDay = !(
+        differenceInDays(convertTZDate(toDate, "client"), convertTZDate(fromDate, "client")) === 1
+    );
     const stringEnd = reportHasMoreThanOneDay
         ? `${formatDate(convertTZDate(report.dateFrom, "client"))} - ${formatDate(convertTZDate(report.dateTo, "client"))}`
         : ` vom ${formatDate(convertTZDate(report.dateTo, "client"))}`;

--- a/packages/postgres/src/query/peaks.ts
+++ b/packages/postgres/src/query/peaks.ts
@@ -362,8 +362,7 @@ async function getEndOfLastSequence(sensorId: string, type: "peak" | "anomaly", 
     const lastSequence = await db
         .select({ time: max(sensorDataSequenceTable.end) })
         .from(sensorDataSequenceTable)
-        .where(and(eq(sensorDataSequenceTable.sensorId, sensorId), eq(sensorDataSequenceTable.type, type)))
-        .limit(1);
+        .where(and(eq(sensorDataSequenceTable.sensorId, sensorId), eq(sensorDataSequenceTable.type, type)));
     if (lastSequence.length > 0) {
         return lastSequence[0].time;
     }


### PR DESCRIPTION
Folgende Probleme traten auf, die hierdurch hoffentlich behoben werden:

```
Error: c: Unable to check out process from the pool due to timeout
    at A (/var/task/apps/admin/.next/server/app/(api)/api/v1/process_peaks/route.js:1:2758)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0)
    at async $.waitForBatch (/opt/rust/nodejs.js:5:6707)
```

```
Uncaught Exception: TypeError: Cannot redefine property: query
    at Function.defineProperties (<anonymous>)
    at eK (/var/task/apps/admin/.next/server/chunks/280.js:10:4291)
    at eR (/var/task/apps/admin/.next/server/chunks/280.js:10:4249)
    at Socket.ek (/var/task/apps/admin/.next/server/chunks/280.js:10:3412)
    at Socket.emit (node:events:519:28)
    at addChunk (node:internal/streams/readable:559:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
    at Readable.push (node:internal/streams/readable:390:5)
    at TCP.onStreamRead (node:internal/stream_base_commons:191:23)
    at TCP.callbackTrampoline (node:internal/async_hooks:130:17)
Node.js process exited with exit status: 129. The logs above can help with debugging the issue.
```

```
Error: c: duplicate key value violates unique constraint "senor_data_sequence_sensor_id_end"
    at A (/var/task/apps/admin/.next/server/app/(api)/api/v1/process_peaks/route.js:1:2758)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0)
    at async $.waitForBatch (/opt/rust/nodejs.js:5:6707)
```