### PR TITLE
Fix update of device timestamp

### DIFF
--- a/packages/postgres/src/schema/device.ts
+++ b/packages/postgres/src/schema/device.ts
@@ -14,7 +14,7 @@ const deviceFields = {
     created: timestamp("created", { mode: "date", withTimezone: true }).default(sql`now()`),
     timestamp: timestamp("timestamp", { mode: "date", withTimezone: true })
         .default(sql`now()`)
-        .$onUpdateFn(() => sql`now()`)
+        .$onUpdateFn(() => new Date())
         .notNull(),
     powerEstimation: numericType("power_estimation"),
     weeklyUsageEstimation: numericType("weekly_usage_estimation"),


### PR DESCRIPTION
Geräte können aktuell nicht bearbeitet und diese nicht zu Peaks zugeordnet werden. Es gibt da aktuell bei Drizzle ein issue: https://github.com/drizzle-team/drizzle-orm/issues/2388

Ich habe da nun den Workaround implementiert. Problem ist damit, dass der die Server-Zeit dann zum Updaten nimmt. Das sollte aber, zumindest nach meinem Verständnis, nicht schlimm sein.