### PR TITLE
Improve loading of daily consumption for reports

### DIFF
--- a/apps/admin/src/lib/reports/graphs.ts
+++ b/apps/admin/src/lib/reports/graphs.ts
@@ -1,4 +1,10 @@
-import { type DailyConsumption, type DailyGoalProgress, formatDate, formatNumber } from "@energyleaf/lib";
+import {
+    type DailyConsumption,
+    type DailyGoalProgress,
+    convertTZDate,
+    formatDate,
+    formatNumber,
+} from "@energyleaf/lib";
 import { renderChart } from "@energyleaf/lib/utils/chart-to-png";
 import type { ChartConfiguration, ChartOptions } from "chart.js/auto";
 import ChartDataLabels from "chartjs-plugin-datalabels";
@@ -11,7 +17,7 @@ export function renderDailyConsumptionChart(dayStatistics: DailyConsumption[]) {
         {
             type: "bar",
             data: {
-                labels: dayStatistics.map((x) => formatDate(x.day)),
+                labels: dayStatistics.map((x) => formatDate(convertTZDate(x.day, "client"))),
                 datasets: [
                     {
                         label: "Täglicher Verbrauch in kWh",

--- a/apps/admin/src/lib/reports/send-reports.ts
+++ b/apps/admin/src/lib/reports/send-reports.ts
@@ -82,8 +82,7 @@ async function getDailyConsumption(sensor: string, dateFrom: Date, interval: num
     const dates = new Array(interval).fill(null).map((_, index) => {
         const date = new Date(dateFrom);
         date.setDate(date.getDate() + index);
-        date.setHours(0, 0, 0, 0);
-        return convertTZDate(date);
+        return date;
     });
 
     const tasks: Promise<DailyConsumption>[] = dates.map(async (date) => {

--- a/apps/web/src/app/(site)/reports/[id]/layout.tsx
+++ b/apps/web/src/app/(site)/reports/[id]/layout.tsx
@@ -51,11 +51,8 @@ export default async function ReportsPageLayout({ children, params }: Props) {
         );
     }
 
-    const toDate = convertTZDate(report.dateTo);
-    const fromDate = convertTZDate(report.dateFrom);
-    const reportHasMoreThanOneDay = !(
-        differenceInDays(convertTZDate(toDate, "client"), convertTZDate(fromDate, "client")) === 1
-    );
+    const reportHasMoreThanOneDay =
+        differenceInDays(convertTZDate(report.dateTo, "client"), convertTZDate(report.dateFrom, "client")) > 0;
     const stringEnd = reportHasMoreThanOneDay
         ? `${formatDate(convertTZDate(report.dateFrom, "client"))} - ${formatDate(convertTZDate(report.dateTo, "client"))}`
         : ` vom ${formatDate(convertTZDate(report.dateTo, "client"))}`;

--- a/apps/web/src/components/reports/ReportSelector.tsx
+++ b/apps/web/src/components/reports/ReportSelector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { formatDate } from "@energyleaf/lib";
+import { convertTZDate, formatDate } from "@energyleaf/lib";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@energyleaf/ui/select";
 import { differenceInDays } from "date-fns";
 import { useRouter } from "next/navigation";
@@ -26,10 +26,13 @@ export default function ReportSelector({ last20Reports, reportId }: ReportSelect
                 </SelectTrigger>
                 <SelectContent>
                     {last20Reports.map((report) => {
-                        const reportHasMoreThanOneDay = !(differenceInDays(report.dateTo, report.dateFrom) === 1);
+                        const from = convertTZDate(report.dateFrom, "client");
+                        const to = convertTZDate(report.dateTo, "client");
+
+                        const reportHasMoreThanOneDay = differenceInDays(to, from) > 0;
                         const dateString = reportHasMoreThanOneDay
-                            ? `Bericht ${formatDate(report.dateFrom)} - ${formatDate(report.dateTo)}`
-                            : `Bericht vom ${formatDate(report.dateFrom)}`;
+                            ? `Bericht ${formatDate(from)} - ${formatDate(to)}`
+                            : `Bericht vom ${formatDate(from)}`;
                         return (
                             <SelectItem key={report.id} value={report.id}>
                                 {dateString}

--- a/apps/web/src/components/reports/ReportView.tsx
+++ b/apps/web/src/components/reports/ReportView.tsx
@@ -1,5 +1,6 @@
 import KeyFiguresOverviewCard from "@/components/reports/key-figures-overview-card";
 import { getReportById } from "@/query/reports";
+import { reportPropsLocalTime } from "@energyleaf/lib";
 import React from "react";
 import DailyAbsoluteEnergyCard from "./daily-absolute-energy-card";
 import DayStatisticsCard from "./day-statistics-card";
@@ -10,11 +11,13 @@ interface Props {
 }
 
 export default async function ReportView(props: Props) {
-    const report = await getReportById(props.reportId, props.userId);
+    let report = await getReportById(props.reportId, props.userId);
 
     if (!report) {
         return null;
     }
+
+    report = reportPropsLocalTime(report);
 
     return (
         <div className="flex flex-col gap-4">

--- a/packages/lib/src/types/report-props.ts
+++ b/packages/lib/src/types/report-props.ts
@@ -1,3 +1,5 @@
+import { convertTZDate } from "../utils/util";
+
 export interface DailyGoalProgress {
     day: Date;
     dailyConsumption: number;
@@ -48,4 +50,24 @@ export interface ReportProps {
      * The values of the last report to compare with the new report
      */
     lastReport?: LastReport;
+}
+
+export function reportPropsLocalTime(props: ReportProps) {
+    return {
+        ...props,
+        dateFrom: convertTZDate(props.dateFrom, "client"),
+        dateTo: convertTZDate(props.dateTo, "client"),
+        dayEnergyStatistics: props.dayEnergyStatistics?.map((stat) => ({
+            ...stat,
+            day: convertTZDate(stat.day, "client"),
+        })),
+        bestDay: {
+            ...props.bestDay,
+            day: convertTZDate(props.bestDay.day, "client"),
+        },
+        worstDay: {
+            ...props.worstDay,
+            day: convertTZDate(props.worstDay.day, "client"),
+        },
+    };
 }

--- a/packages/mail/src/lib/mail.tsx
+++ b/packages/mail/src/lib/mail.tsx
@@ -1,4 +1,4 @@
-import { DismissedReasonEnum, type ReportProps, convertTZDate, formatDate } from "@energyleaf/lib";
+import { DismissedReasonEnum, type ReportProps, formatDate, reportPropsLocalTime } from "@energyleaf/lib";
 import type * as React from "react";
 import { Resend } from "resend";
 import AccountActivatedTemplate from "../templates/account-activated";
@@ -256,20 +256,7 @@ export async function sendReport(options: ReportMailOptions) {
 
     const optionsWithClientDates = {
         ...options,
-        dateFrom: convertTZDate(options.dateFrom, "client"),
-        dateTo: convertTZDate(options.dateTo, "client"),
-        dayEnergyStatistics: options.dayEnergyStatistics?.map((stat) => ({
-            ...stat,
-            day: convertTZDate(stat.day, "client"),
-        })),
-        bestDay: {
-            ...options.bestDay,
-            day: convertTZDate(options.bestDay.day, "client"),
-        },
-        worstDay: {
-            ...options.worstDay,
-            day: convertTZDate(options.worstDay.day, "client"),
-        },
+        ...reportPropsLocalTime(options),
     };
 
     const resp = await resend.emails.send({

--- a/packages/postgres/src/query/report.ts
+++ b/packages/postgres/src/query/report.ts
@@ -41,12 +41,12 @@ export async function getUsersWitDueReport() {
             and(
                 or(
                     gt(
-                        sql`DATE_PART('day', NOW()::timestamp - ${reportConfigTable.timestampLast})`,
+                        sql`DATE_PART('day', NOW()::timestamp - DATE_TRUNC('day', ${reportConfigTable.timestampLast}))`,
                         reportConfigTable.interval,
                     ),
                     and(
                         eq(
-                            sql`DATE_PART('day', NOW()::timestamp - ${reportConfigTable.timestampLast})`,
+                            sql`DATE_PART('day', NOW()::timestamp - DATE_TRUNC('day', ${reportConfigTable.timestampLast}))`,
                             reportConfigTable.interval,
                         ),
                         lte(reportConfigTable.time, new Date().getHours()),


### PR DESCRIPTION
# Changelog
- Es wurde ein Fehler behoben, durch den bei den Berichten der tägliche Verbrauch immer mit 0 angegeben wurde, wenn die Web API unter Zeitzone UTC läuft.
- Es wurde ein Fehler behoben, durch den die Berichte nicht immer zur in den Einstellungen festgelegten Zeit gesendet wurden, wenn der letzte Bericht an einer anderen Uhrzeit am Tag gesendet wurde.
- Im Berichte-Reiter der Web App und in der Berichtsmail werden nun die Daten in der richtigen Zeitzone (Europa/Berlin) dargestellt.

# Hotfix
Das werde ich auf main cherry-picken