### PR TITLE
Bugfix/pge 269 peaks uberlappend und unvollstandig

### DIFF
--- a/apps/admin/src/app/(api)/api/v1/mark_peaks/route.ts
+++ b/apps/admin/src/app/(api)/api/v1/mark_peaks/route.ts
@@ -17,38 +17,32 @@ export const GET = async (req: NextRequest) => {
         const sensors = await getAllSensors(true);
         const sensorIds = sensors.map((d) => d.id);
 
-        const promises: Promise<void>[] = [];
         waitUntil(
             log("mark-peaks/length", "info", "mark-peaks", "api", {
                 numberOfSensors: sensorIds.length,
             }),
         );
-        const processEndpoint = `https://${getUrl(env)}/api/v1/process_peaks`;
+        const processEndpoint = `http://${getUrl(env)}/api/v1/process_peaks`;
         for (let i = 0; i < sensorIds.length; i++) {
             const sensorId = sensorIds[i];
 
-            const fn = async () => {
-                try {
-                    await fetch(processEndpoint, {
-                        method: "POST",
-                        headers: {
-                            "Content-Type": "application/json",
-                        },
-                        body: JSON.stringify({
-                            secret: cronSecret,
-                            sensorId,
-                        }),
-                    });
-                } catch (err) {
-                    console.error(err);
-                    waitUntil(logError("mark-peaks/failed", "mark-peaks", "api", { sensorId }, err));
-                }
-            };
-            promises.push(fn());
+            try {
+                await fetch(processEndpoint, {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        secret: cronSecret,
+                        sensorId,
+                    }),
+                });
+            } catch (err) {
+                console.error(err);
+                waitUntil(logError("mark-peaks/failed", "mark-peaks", "api", { sensorId }, err));
+            }
         }
 
-        // use allSettled so we dont abort if one fails
-        await Promise.allSettled(promises);
         return NextResponse.json({ statusMessage: "Peaks successfully marked and classified where applicable." });
     } catch (err) {
         waitUntil(

--- a/apps/admin/src/app/(api)/api/v1/mark_peaks/route.ts
+++ b/apps/admin/src/app/(api)/api/v1/mark_peaks/route.ts
@@ -22,7 +22,7 @@ export const GET = async (req: NextRequest) => {
                 numberOfSensors: sensorIds.length,
             }),
         );
-        const processEndpoint = `http://${getUrl(env)}/api/v1/process_peaks`;
+        const processEndpoint = `https://${getUrl(env)}/api/v1/process_peaks`;
         for (let i = 0; i < sensorIds.length; i++) {
             const sensorId = sensorIds[i];
 

--- a/apps/admin/src/app/(api)/api/v1/process_peaks/route.ts
+++ b/apps/admin/src/app/(api)/api/v1/process_peaks/route.ts
@@ -28,26 +28,20 @@ const fn = async (sensorId: string) => {
         startDate = result.start;
         endDate = result.end;
 
-        if (!startDate || !endDate) {
-            throw new Error("Start date or end date is undefined.");
-        }
-
         const user = await getUserBySensorId(sensorId);
 
         if (user && fulfills(user.appVersion, Versions.support)) {
             const peaks = await getSequencesBySensor(sensorId, { start: startDate, end: endDate });
 
-            const peaksToClassify = await Promise.all(
-                peaks.map(async (peak) => {
-                    return {
-                        id: peak.id,
-                        electricity: peak.sensorData.map((data) => ({
-                            timestamp: data.timestamp.toISOString(),
-                            power: data.consumption / 1000,
-                        })),
-                    };
-                }),
-            );
+            const peaksToClassify = peaks.map((peak) => {
+                return {
+                    id: peak.id,
+                    electricity: peak.sensorData.map((data) => ({
+                        timestamp: data.timestamp.toISOString(),
+                        power: data.consumption / 1000,
+                    })),
+                };
+            });
 
             await classifyAndSaveDevicesForPeaks(peaksToClassify, user.userId);
         }

--- a/packages/postgres/src/query/peaks.ts
+++ b/packages/postgres/src/query/peaks.ts
@@ -326,13 +326,13 @@ async function getSequenceMarkingPeriod(sensorId: string, type: "peak" | "anomal
     if (lastMarking) {
         const laterDate = lastSequenceEnd && lastSequenceEnd > lastMarking ? lastSequenceEnd : lastMarking;
         const start = new Date(laterDate);
-        start.setMilliseconds(start.getMilliseconds() + 1); // Add one milliseconds so that the periods don't overlap
+        start.setMilliseconds(start.getMilliseconds() + 1000); // Add one second so that the periods don't overlap
         return { start: start <= end ? start : end, end };
     }
 
     if (lastSequenceEnd) {
         const start = new Date(lastSequenceEnd);
-        start.setMilliseconds(start.getMilliseconds() + 1); // Add one milliseconds so that the periods don't overlap
+        start.setMilliseconds(start.getMilliseconds() + 1000); // Add one second so that the periods don't overlap
         return { start: start <= end ? start : end, end };
     }
 


### PR DESCRIPTION
# Fehler
- Beim Aufrufen des Endpunkts kam es zu folgendem Fehler:
```
{"sensorId":"59oIKuE6YVebfE7YY6FQZd41OXqeQg","start":"2024-09-11T17:00:21.434Z","end":"2024-09-11T17:30:22.053Z","error":{"name":"Error","message":"c: out of shared memory","stack":"    at A (/var/task/apps/admin/.next/server/app/(api)/api/v1/process_peaks/route.js:1:2764)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Promise.all (index 0)\n    at async $.waitForBatch (/opt/rust/nodejs.js:5:6707)"}}
```
- Mitunter gab es Überschneidungen bei Peaks

# Changelog
- Unnötige `Promise.all` Aufrufe bei Peak-Erkennung entfernt.
- Größerer Buffer zwischen Timestamp der letzten Erkennung und dem Start der neuen Erkennung.